### PR TITLE
Add clear cache on updates functionality

### DIFF
--- a/class.varnish-cache-admin.php
+++ b/class.varnish-cache-admin.php
@@ -14,7 +14,6 @@ class ClpVarnishCacheAdmin {
         add_action('admin_menu', array($this, 'add_admin_menu'), 100);
         add_action('network_admin_menu', array($this, 'add_admin_menu'), 100);
         add_action('admin_enqueue_scripts', array($this, 'add_css'));
-        add_action('upgrader_process_complete', array($this, 'clear_cache_on_updates'), 10, 2);
         $this->check_entire_cache_purge();
     }
 
@@ -146,27 +145,4 @@ class ClpVarnishCacheAdmin {
         return $svg;
     }
 
-    public function clear_cache_on_updates($upgrader_object, $options) {
-        
-        // Return if not called because of an update to WordPress core, a plugin, a theme or a bulk update.
-        if ('update' !== $options['action'] && 'bulk-update' !== $options['action']) {
-            return;
-        }
-
-        $varnish_cache_manager = $this->get_clp_cache_manager();
-
-        // Check if Varnish Cache is enabled and should be cleared on updates
-        if (true === $varnish_cache_manager->is_enabled() && true === $varnish_cache_manager->should_clear_on_updates()) {
-
-            $site_url = get_site_url();
-            $parsed_url = parse_url($site_url);
-            $host = $parsed_url['host'];
-            try {
-                $varnish_cache_manager->purge_host($host);
-                error_log('Varnish Cache has been purged for host: ' . $host);
-            } catch (\Throwable $th) {
-                error_log('Error while trying to automatically purge host cache: ' . $th);
-            }
-        }
-    }
 }

--- a/class.varnish-cache-manager.php
+++ b/class.varnish-cache-manager.php
@@ -61,6 +61,12 @@ class ClpVarnishCacheManager {
         return $should_clear;
     }
 
+    public function clear_on_post_page_update() {
+        $settings = $this->get_cache_settings();
+        $clear_post_page = (true === isset($settings['clearOnPostPageUpdate']) && true === $settings['clearOnPostPageUpdate'] ? true : false);
+        return $clear_post_page;
+    }
+
     public function write_cache_settings(array $settings) {
         $settings_file = sprintf('%s/.varnish-cache/settings.json', rtrim(getenv('HOME'), '/'));
         $settings = json_encode($settings, JSON_PRETTY_PRINT);

--- a/class.varnish-cache-manager.php
+++ b/class.varnish-cache-manager.php
@@ -55,6 +55,12 @@ class ClpVarnishCacheManager {
         return $this->cache_settings;
     }
 
+    public function should_clear_on_updates() {
+        $settings = $this->get_cache_settings();
+        $should_clear = (true === isset($settings['clearOnUpdates']) && true === $settings['clearOnUpdates'] ? true : false);
+        return $should_clear;
+    }
+
     public function write_cache_settings(array $settings) {
         $settings_file = sprintf('%s/.varnish-cache/settings.json', rtrim(getenv('HOME'), '/'));
         $settings = json_encode($settings, JSON_PRETTY_PRINT);

--- a/clp-varnish-cache.php
+++ b/clp-varnish-cache.php
@@ -27,35 +27,3 @@ if (true === $is_admin) {
     require_once CLP_VARNISH_PLUGIN_DIR . 'class.varnish-cache-admin.php';
     $clp_varnish_cache_admin = new ClpVarnishCacheAdmin();
 }
-
-function clear_cache_on_updates($upgrader_object, $options)
-{
-
-    // Return if not called because of an update to WordPress core, a plugin, a theme or a bulk update.
-    if ('update' !== $options['action'] && 'bulk-update' !== $options['action']) {
-        return;
-    }
-
-    require_once CLP_VARNISH_PLUGIN_DIR . 'class.varnish-cache-manager.php';
-    $clp_varnish_cache_manager = new ClpVarnishCacheManager();
-
-    // Check if Varnish Cache is enabled and should be cleared on updates
-    if (true === $clp_varnish_cache_manager->is_enabled() && true === $clp_varnish_cache_manager->should_clear_on_updates()) {
-
-        // Get the host
-        $site_url = get_site_url();
-        $parsed_url = parse_url($site_url);
-        $host = $parsed_url['host'];
-
-        try {
-            // Clear Varnish Cache
-            $clp_varnish_cache_manager->purge_host($host);
-        } catch (\Throwable $th) {
-            error_log('Error: ' . $th);
-        }
-
-    }
-}
-
-add_action('upgrader_process_complete', 'clear_cache_on_updates', 10, 2);
-

--- a/clp-varnish-cache.php
+++ b/clp-varnish-cache.php
@@ -21,9 +21,79 @@ if (false === function_exists('add_action')) {
 define('CLP_VARNISH_VERSION', '1.0.0');
 $is_admin = is_admin();
 
+define('CLP_VARNISH_PLUGIN_DIR', plugin_dir_path(__FILE__));
+require_once CLP_VARNISH_PLUGIN_DIR . 'class.varnish-cache-manager.php';
+
 if (true === $is_admin) {
-    define('CLP_VARNISH_PLUGIN_DIR', plugin_dir_path(__FILE__));
-    require_once CLP_VARNISH_PLUGIN_DIR . 'class.varnish-cache-manager.php';
     require_once CLP_VARNISH_PLUGIN_DIR . 'class.varnish-cache-admin.php';
     $clp_varnish_cache_admin = new ClpVarnishCacheAdmin();
 }
+
+function clear_cache_on_updates($upgrader_object, $options) {
+        
+    // Return if not called because of an update to WordPress core, a plugin, a theme or a bulk update.
+    if ('update' !== $options['action'] && 'bulk-update' !== $options['action']) {
+        return;
+    }
+
+    $varnish_cache_manager = new ClpVarnishCacheManager();
+
+    // Check if Varnish Cache is enabled and should be cleared on updates
+    if (true === $varnish_cache_manager->is_enabled() && true === $varnish_cache_manager->should_clear_on_updates()) {
+
+        $site_url = get_site_url();
+        $parsed_url = parse_url($site_url);
+        $host = $parsed_url['host'];
+        try {
+            $varnish_cache_manager->purge_host($host);
+            error_log('Varnish Cache has been purged for host: ' . $host);
+        } catch (\Throwable $th) {
+            error_log('Error while trying to automatically purge host cache: ' . $th);
+        }
+    }
+}
+
+add_action('upgrader_process_complete', 'clear_cache_on_updates', 10, 2);
+
+function clear_post_page($post_id, $post, $update) {
+
+    error_log('Clear Post Page Function Called');
+
+    // If this is just a revision, don't purge cache.
+    if ( wp_is_post_revision( $post_id ) ) {
+        error_log('Post is a revision, skipping cache update.');
+        return;
+    }
+
+    // If this post is not published, don't purge cache.
+    if ( 'publish' !== $post->post_status ) {
+        error_log('Post is not published, skipping cache update.');
+        return;
+    }
+
+    // If this post is not a post or page, don't purge cache.
+    if ( !in_array( $post->post_type, array( 'post', 'page' ) ) ) {
+        error_log('Post is not a post or page, skipping cache update.');
+        return;
+    }
+
+    $varnish_cache_manager = new ClpVarnishCacheManager();
+
+    // Check if Varnish Cache is enabled and should be cleared on post/page updates
+    if (true === $varnish_cache_manager->is_enabled() && true === $varnish_cache_manager->clear_on_post_page_update()) {
+
+        // Get the URL of the post
+        $post_url = get_permalink($post_id);
+
+        try {
+            $varnish_cache_manager->purge_url($post_url);
+            error_log('Varnish Cache has been purged for url: ' . $post_url);
+        } catch (\Throwable $th) {
+            error_log('Error while trying to automatically purge host cache: ' . $th);
+        }
+    } else {
+        error_log('Varnish Cache is not enabled or should not be cleared on post/page updates.');
+    }
+}
+
+add_action('save_post', 'clear_post_page', 10, 3);

--- a/clp-varnish-cache.php
+++ b/clp-varnish-cache.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /*
  * Plugin Name: CLP Varnish Cache
  * Description: Varnish Cache Plugin by cloudpanel.io
@@ -13,7 +13,7 @@
  * GitHub Branch: master
  */
 
-if (false ===  function_exists('add_action')) {
+if (false === function_exists('add_action')) {
     echo 'Hi there!  I\'m just a plugin, not much I can do when called directly.';
     exit;
 }
@@ -22,8 +22,40 @@ define('CLP_VARNISH_VERSION', '1.0.0');
 $is_admin = is_admin();
 
 if (true === $is_admin) {
-    define('CLP_VARNISH_PLUGIN_DIR', plugin_dir_path( __FILE__));
+    define('CLP_VARNISH_PLUGIN_DIR', plugin_dir_path(__FILE__));
     require_once CLP_VARNISH_PLUGIN_DIR . 'class.varnish-cache-manager.php';
     require_once CLP_VARNISH_PLUGIN_DIR . 'class.varnish-cache-admin.php';
     $clp_varnish_cache_admin = new ClpVarnishCacheAdmin();
 }
+
+function clear_cache_on_updates($upgrader_object, $options)
+{
+
+    // Return if not called because of an update to WordPress core, a plugin, a theme or a bulk update.
+    if ('update' !== $options['action'] && 'bulk-update' !== $options['action']) {
+        return;
+    }
+
+    require_once CLP_VARNISH_PLUGIN_DIR . 'class.varnish-cache-manager.php';
+    $clp_varnish_cache_manager = new ClpVarnishCacheManager();
+
+    // Check if Varnish Cache is enabled and should be cleared on updates
+    if (true === $clp_varnish_cache_manager->is_enabled() && true === $clp_varnish_cache_manager->should_clear_on_updates()) {
+
+        // Get the host
+        $site_url = get_site_url();
+        $parsed_url = parse_url($site_url);
+        $host = $parsed_url['host'];
+
+        try {
+            // Clear Varnish Cache
+            $clp_varnish_cache_manager->purge_host($host);
+        } catch (\Throwable $th) {
+            error_log('Error: ' . $th);
+        }
+
+    }
+}
+
+add_action('upgrader_process_complete', 'clear_cache_on_updates', 10, 2);
+

--- a/pages/clp-varnish-cache.php
+++ b/pages/clp-varnish-cache.php
@@ -22,6 +22,7 @@ if (true === isset($_POST['action']) && 'save-settings' == sanitize_text_field($
     $excluded_params = array_map('trim', array_filter(explode(',', getPostValue('excluded-params'))));
     $excludes = (true === isset($_POST['excludes']) ? sanitize_textarea_field($_POST['excludes']) : '');
     $excludes = array_map('trim', array_filter(explode(PHP_EOL, $excludes)));
+    $clear_on_updates = (1 == getPostValue('clear-on-updates')  ? true : false);
     if (false === empty($server) && false === empty($cache_lifetime) && false === empty($cache_tag_prefix)) {
         $cache_settings = [
             'enabled'        => $enabled,
@@ -30,6 +31,7 @@ if (true === isset($_POST['action']) && 'save-settings' == sanitize_text_field($
             'cacheLifetime'  => $cache_lifetime,
             'excludes'       => $excludes,
             'excludedParams' => $excluded_params,
+            'clearOnUpdates' => $clear_on_updates,
         ];
         $clp_cache_manager->write_cache_settings($cache_settings);
         $clp_cache_manager->reset_cache_settings();
@@ -80,6 +82,7 @@ $cache_lifetime = $clp_cache_manager->get_cache_lifetime();
 $cache_tag_prefix = $clp_cache_manager->get_cache_tag_prefix();
 $excluded_params = $clp_cache_manager->get_excluded_params();
 $excludes = $clp_cache_manager->get_excludes();
+$clear_on_updates = $clp_cache_manager->should_clear_on_updates();
 
 ?>
 <h1 id="clp-varnish-cache"><?php esc_html_e( 'CLP Varnish Cache', 'clp-varnish-cache' ); ?></h1>
@@ -154,6 +157,15 @@ $excludes = $clp_cache_manager->get_excludes();
                   <td>
                     <textarea name="excludes" rows="6"><?php echo esc_textarea($excludes); ?></textarea>
                     <p class="description"><?php esc_html_e( 'Urls and files that Varnish Cache shouldn\'t cache.', 'clp-varnish-cache' ); ?></p>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="field-name">
+                    <?php esc_html_e( 'Clear cache on updates', 'clp-varnish-cache' ); ?>:
+                  </td>
+                  <td>
+                    <input type="checkbox" name="clear-on-updates" <?php echo (true === $clear_on_updates ? 'checked' : ''); ?> value="1" />
+                    <p class="description"><?php esc_html_e( 'Automatically clear cache when an update of core, theme or plugin has been performed.', 'clp-varnish-cache' ); ?></p>
                   </td>
                 </tr>
               </tbody>

--- a/pages/clp-varnish-cache.php
+++ b/pages/clp-varnish-cache.php
@@ -165,7 +165,7 @@ $clear_on_updates = $clp_cache_manager->should_clear_on_updates();
                   </td>
                   <td>
                     <input type="checkbox" name="clear-on-updates" <?php echo (true === $clear_on_updates ? 'checked' : ''); ?> value="1" />
-                    <p class="description"><?php esc_html_e( 'Automatically clear cache when an update of core, theme or plugin has been performed.', 'clp-varnish-cache' ); ?></p>
+                    <p class="description"><?php esc_html_e( 'Automatically clear the cache when an update of WordPress Core, a theme or a plugin has been performed.', 'clp-varnish-cache' ); ?></p>
                   </td>
                 </tr>
               </tbody>

--- a/pages/clp-varnish-cache.php
+++ b/pages/clp-varnish-cache.php
@@ -23,6 +23,7 @@ if (true === isset($_POST['action']) && 'save-settings' == sanitize_text_field($
     $excludes = (true === isset($_POST['excludes']) ? sanitize_textarea_field($_POST['excludes']) : '');
     $excludes = array_map('trim', array_filter(explode(PHP_EOL, $excludes)));
     $clear_on_updates = (1 == getPostValue('clear-on-updates')  ? true : false);
+    $clear_post_page = (1 == getPostValue('clear-post-page')  ? true : false);
     if (false === empty($server) && false === empty($cache_lifetime) && false === empty($cache_tag_prefix)) {
         $cache_settings = [
             'enabled'        => $enabled,
@@ -32,6 +33,7 @@ if (true === isset($_POST['action']) && 'save-settings' == sanitize_text_field($
             'excludes'       => $excludes,
             'excludedParams' => $excluded_params,
             'clearOnUpdates' => $clear_on_updates,
+            'clearOnPostPageUpdate' => $clear_post_page,
         ];
         $clp_cache_manager->write_cache_settings($cache_settings);
         $clp_cache_manager->reset_cache_settings();
@@ -83,6 +85,7 @@ $cache_tag_prefix = $clp_cache_manager->get_cache_tag_prefix();
 $excluded_params = $clp_cache_manager->get_excluded_params();
 $excludes = $clp_cache_manager->get_excludes();
 $clear_on_updates = $clp_cache_manager->should_clear_on_updates();
+$clear_post_page = $clp_cache_manager->clear_on_post_page_update();
 
 ?>
 <h1 id="clp-varnish-cache"><?php esc_html_e( 'CLP Varnish Cache', 'clp-varnish-cache' ); ?></h1>
@@ -161,11 +164,20 @@ $clear_on_updates = $clp_cache_manager->should_clear_on_updates();
                 </tr>
                 <tr>
                   <td class="field-name">
-                    <?php esc_html_e( 'Clear cache on updates', 'clp-varnish-cache' ); ?>:
+                    <?php esc_html_e( 'Clear cache on system, theme or plugin updates', 'clp-varnish-cache' ); ?>:
                   </td>
                   <td>
                     <input type="checkbox" name="clear-on-updates" <?php echo (true === $clear_on_updates ? 'checked' : ''); ?> value="1" />
                     <p class="description"><?php esc_html_e( 'Automatically clear the cache when an update of WordPress Core, a theme or a plugin has been performed.', 'clp-varnish-cache' ); ?></p>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="field-name">
+                    <?php esc_html_e( 'Clear cache on post or page save', 'clp-varnish-cache' ); ?>:
+                  </td>
+                  <td>
+                    <input type="checkbox" name="clear-post-page" <?php echo (true === $clear_post_page ? 'checked' : ''); ?> value="1" />
+                    <p class="description"><?php esc_html_e( 'Automatically clear the cache of a specific page when that page has been saved.', 'clp-varnish-cache' ); ?></p>
                   </td>
                 </tr>
               </tbody>


### PR DESCRIPTION
Added functionality to let CloudPanel Plugin clear host cache automatically when a theme, plugin or WordPress core update has finished. Especially helpful for website owners using theme builders such as Elementor.

Handling feature request in issue #4 

Edit 14 feb: I refactored some of the code to follow the existing code style of the plugin (Object oriented programming).