### PR TITLE
Implement Automated Varnish Cache Purge for Posts, Pages, CPTs & Sitemaps

### DIFF
--- a/class.varnish-cache-purge.php
+++ b/class.varnish-cache-purge.php
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * CLP Varnish Cache purge logic hooked into WordPress events.
+ *
+ * This class connects WordPress hooks (like save_post) with the
+ * ClpVarnishCacheManager so that cache is purged automatically
+ * when content changes.
+ */
+if (false === class_exists('ClpVarnishCachePurge')) {
+
+    class ClpVarnishCachePurge
+    {
+        /**
+         * @var ClpVarnishCacheManager
+         */
+        private $manager;
+
+        /**
+         * Constructor.
+         *
+         * @param ClpVarnishCacheManager $manager Cache manager instance.
+         */
+        public function __construct($manager)
+        {
+            $this->manager = $manager;
+
+            // Register hooks.
+            add_action('save_post', array($this, 'auto_purge_on_save'), 20, 3);
+
+            // Show admin notice after redirect, if purge happened.
+            add_action('admin_notices', array($this, 'maybe_show_purge_notice'));
+        }
+
+        /**
+         * Automatically purge the post URL and related sitemaps
+         * when public content is saved and published.
+         *
+         * @param int     $post_id Post ID.
+         * @param WP_Post $post    Post object.
+         * @param bool    $update  Whether this is an existing post being updated.
+         */
+        public function auto_purge_on_save($post_id, $post, $update)
+        {
+            // Ignore autosaves and revisions.
+            if (true === wp_is_post_autosave($post_id) || true === wp_is_post_revision($post_id)) {
+                return;
+            }
+
+            // Only handle public post types (posts, pages, public CPTs).
+            $post_type_object = get_post_type_object($post->post_type);
+            if (null === $post_type_object || true !== $post_type_object->public) {
+                return;
+            }
+
+            // Only when the post is published.
+            if ('publish' !== $post->post_status) {
+                return;
+            }
+
+            // Only run when cache is enabled.
+            if (true !== $this->manager->is_enabled()) {
+                return;
+            }
+
+            // Purge the post URL.
+            $url = get_permalink($post_id);
+            if (empty($url)) {
+                return;
+            }
+
+            $purged = false;
+
+            try {
+                $this->manager->purge_url($url);
+                $purged = true;
+            } catch (Exception $e) {
+                // Note:
+                // ClpVarnishCacheManager::purge() currently echoes and exits on error.
+                // This catch is mainly for future compatibility if that behaviour changes.
+            }
+
+            if (true === $purged) {
+                // Purge relevant sitemaps.
+                $this->purge_sitemaps();
+
+                // Flag for notice on redirect back to the edit screen.
+                add_filter('redirect_post_location', array($this, 'add_purged_query_arg'), 99, 1);
+            }
+        }
+
+        /**
+         * Purge sitemap URLs that are likely to change when content is updated.
+         *
+         * In a future enhancement, these URLs could be made configurable via plugin settings.
+         */
+        private function purge_sitemaps()
+        {
+            $sitemaps = array(
+                // Core WordPress sitemap.
+                home_url('/wp-sitemap.xml'),
+
+                // Common SEO plugin sitemaps (for example Yoast SEO).
+                home_url('/sitemap_index.xml'),
+                home_url('/post-sitemap.xml'),
+                home_url('/page-sitemap.xml'),
+            );
+
+            $sitemaps = array_unique(array_filter($sitemaps));
+
+            foreach ($sitemaps as $sitemap_url) {
+                try {
+                    $this->manager->purge_url($sitemap_url);
+                } catch (Exception $e) {
+                    // Same note as above about current purge() behaviour.
+                }
+            }
+        }
+
+        /**
+         * Add a query arg to the post redirect URL to indicate purge success.
+         *
+         * @param string $location Redirect URL.
+         * @return string
+         */
+        public function add_purged_query_arg($location)
+        {
+            return add_query_arg('clp_vc_purged', 1, $location);
+        }
+
+        /**
+         * Show a success notice in the admin if a purge happened on the previous request.
+         */
+        public function maybe_show_purge_notice()
+        {
+            if (false === is_admin()) {
+                return;
+            }
+
+            if (!isset($_GET['clp_vc_purged']) || '1' !== sanitize_text_field(wp_unslash($_GET['clp_vc_purged']))) {
+                return;
+            }
+
+            // Optional: limit to post edit/list screens.
+            $screen = function_exists('get_current_screen') ? get_current_screen() : null;
+            if ($screen && !in_array($screen->base, array('post', 'edit'), true)) {
+                // Only show on post edit or list screens.
+                return;
+            }
+            ?>
+            <div class="notice notice-success is-dismissible">
+                <p><strong><?php esc_html_e('Varnish cache has been purged for this content (including sitemaps).', 'clp-varnish-cache'); ?></strong></p>
+            </div>
+            <?php
+        }
+    }
+}

--- a/clp-varnish-cache.php
+++ b/clp-varnish-cache.php
@@ -21,9 +21,19 @@ if (false ===  function_exists('add_action')) {
 define('CLP_VARNISH_VERSION', '1.0.2');
 $is_admin = is_admin();
 
+// Always define plugin dir so it can be used in all contexts.
+define('CLP_VARNISH_PLUGIN_DIR', plugin_dir_path(__FILE__));
+
+// Core classes used in both frontend and admin.
+require_once CLP_VARNISH_PLUGIN_DIR . 'class.varnish-cache-manager.php';
+require_once CLP_VARNISH_PLUGIN_DIR . 'class.varnish-cache-purge.php';
+
+// Instantiate core services.
+$clp_varnish_cache_manager = new ClpVarnishCacheManager();
+$clp_varnish_cache_purge   = new ClpVarnishCachePurge($clp_varnish_cache_manager);
+
+// Admin-specific functionality (unchanged behaviour).
 if (true === $is_admin) {
-    define('CLP_VARNISH_PLUGIN_DIR', plugin_dir_path( __FILE__));
-    require_once CLP_VARNISH_PLUGIN_DIR . 'class.varnish-cache-manager.php';
     require_once CLP_VARNISH_PLUGIN_DIR . 'class.varnish-cache-admin.php';
     $clp_varnish_cache_admin = new ClpVarnishCacheAdmin();
 }


### PR DESCRIPTION
### Summary

This pull request introduces automatic Varnish cache purging whenever WordPress content is updated.
The feature ensures that edited or newly published posts, pages, and public custom post types immediately trigger Varnish to purge the related URL(s).

To maintain indexing accuracy, this PR also purges WordPress, Yoast, and Rank-Math style sitemap URLs.

### Key Features

🔄 Automatic cache purge on publish/update for:

- Posts
- Pages
- Public Custom Post Types

🗺️ Automatic sitemap purge, including:

  - /wp-sitemap.xml
  - /sitemap_index.xml
  - /post-sitemap.xml
  - /page-sitemap.xml

🔐 Only purges when Varnish cache is enabled in plugin settings
📝 Ignores autosaves and revisions
🎯 Triggers only for public post types
🎉 Displays a success notice in the WordPress admin after purge
🧩 All logic added inside a dedicated class: `class.varnish-cache-purge.php`
🧼 Minimal changes to the main plugin loader
🔄 Fully backward-compatible

### Implementation Details

A new file was introduced:

`class.varnish-cache-purge.php`

This class:
- Hooks into save_post
- Detects when purging should occur
- Uses existing ClpVarnishCacheManager::purge_url()
- Purges relevant sitemap URLs
- Adds a redirect query parameter to show success messages in the admin UI

The main plugin file (clp-varnish-cache.php) was updated to load and initialize this class.
All logic follows WordPress coding standards and CloudPanel’s plugin structure.

### Testing Performed

Verified auto-purge is triggered correctly under CloudPanel + Varnish
Confirmed sitemap purge execution
Tested on:

- Posts
- Pages
- CPTs

Verified skip conditions:

- Autosaves
- Revisions
- Draft/unpublished posts

Confirmed no errors in admin settings page
Confirmed purges only occur when the plugin’s Enable Varnish Cache option is enabled

### Why This Improvement Matters

- Prevents stale content from being served through Varnish
- Ensures fresh content is immediately available
- Improves SEO accuracy by keeping sitemaps current
- Reduces manual purging and operational overhead
- Matches modern Varnish + WordPress best practices

### Backward Compatibility
This update introduces no breaking changes:

- Admin UI remains unchanged
- Settings structure is unchanged
- Cache manager behavior remains intact
- Existing manual purge functionality is unaffected

The feature is additive, safe, and optional (depends on “Enable Varnish Cache” setting).