### PR TITLE
Update class.varnish-cache-admin.php

### DIFF
--- a/class.varnish-cache-admin.php
+++ b/class.varnish-cache-admin.php
@@ -19,6 +19,13 @@ class ClpVarnishCacheAdmin {
 
     private function check_entire_cache_purge() {
         if (true === isset($_GET['clp-varnish-cache']) && 'purge-entire-cache' == sanitize_text_field($_GET['clp-varnish-cache'])) {
+            if (false === current_user_can('manage_options')) {                                   
+                return;                                                                           
+            }                                                                                     
+            if (false === isset($_GET['_wpnonce']) || false === wp_verify_nonce(sanitize_te       
+         +xt_field($_GET['_wpnonce']), 'purge-entire-cache')) {
+                return;                                                                           
+            }   
             $host = (true === isset($_SERVER['HTTP_HOST']) && false === empty(sanitize_text_field($_SERVER['HTTP_HOST'])) ? sanitize_text_field($_SERVER['HTTP_HOST']) : '');
             if (false === empty($host)) {
                 $this->clp_varnish_cache_manager->purge_host($host);

--- a/class.varnish-cache-admin.php
+++ b/class.varnish-cache-admin.php
@@ -22,8 +22,7 @@ class ClpVarnishCacheAdmin {
             if (false === current_user_can('manage_options')) {                                   
                 return;                                                                           
             }                                                                                     
-            if (false === isset($_GET['_wpnonce']) || false === wp_verify_nonce(sanitize_te       
-         +xt_field($_GET['_wpnonce']), 'purge-entire-cache')) {
+            if (false === isset($_GET['_wpnonce']) || false === wp_verify_nonce(sanitize_text_field($_GET['_wpnonce']), 'purge-entire-cache')) {
                 return;                                                                           
             }   
             $host = (true === isset($_SERVER['HTTP_HOST']) && false === empty(sanitize_text_field($_SERVER['HTTP_HOST'])) ? sanitize_text_field($_SERVER['HTTP_HOST']) : '');


### PR DESCRIPTION
Resolve security issue 
CVE ID: CVE‑2026‑24525                                                                                    
  Type: Missing Authorization / Broken Access Control   

● The primary vulnerability is in class.varnish-cache-admin.php at lines 20-32 in the                       
  check_entire_cache_purge() function:                                                                      
                                                                                                            
  private function check_entire_cache_purge() {                                                             
      if (true === isset($_GET['clp-varnish-cache']) && 'purge-entire-cache' ==                             
  sanitize_text_field($_GET['clp-varnish-cache'])) {                                                        
          // NO current_user_can() check here!                                                              
          // NO wp_verify_nonce() check here!                                                               
          $host = ...                                                                                       
          $this->clp_varnish_cache_manager->purge_host($host);                                              
          $this->clp_varnish_cache_manager->purge_tag($cache_tag_prefix);                                   
      }                                                                                                     
  }                                                                                                         
                                                                                                            
  The problem:                                                                                              
                                                                                                            
  1. Line 17: This function is called from init() on every admin initialization                             
  2. Lines 20-31: The function checks only for a GET parameter clp-varnish-cache=purge-entire-cache and then immediately executes cache purge operations                                                              
  3. Missing: No current_user_can() capability check                                                        
  4. Missing: No wp_verify_nonce() verification - even though a nonce URL is generated at line 67, it's      never verified                                                                                            
                                                                                                            
  Attack vector:                                                                                            
  Any user (even unauthenticated) who can access /wp-admin/ can trigger a full cache purge by visiting:     
  /wp-admin/?clp-varnish-cache=purge-entire-cache                                                           
                                                                                                            
  The fix should add both checks before performing the purge:                                               
                                                                                                            
  private function check_entire_cache_purge() {                                                             
      if (true === isset($_GET['clp-varnish-cache']) && 'purge-entire-cache' ==                             
  sanitize_text_field($_GET['clp-varnish-cache'])) {                                                        
          // Add these two checks:                                                                          
          if (!current_user_can('manage_options')) {                                                        
              return;                                                                                       
          }                                                                                                 
          if (!wp_verify_nonce($_GET['_wpnonce'], 'purge-entire-cache')) {                                  
              return;                                                                                       
          }                                                                                                 
          // ... rest of the function                                                                       
      }                                                                                                     
  }