### PR TITLE
Fix fatal error when purging cache from admin bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-With the plugin **CLP Varnish Cache Plugin** for **WordPress**, you can manage the cache settings and perform purge operations.
+# CLP Varnish Cache (Fork)
+
+This is a fork of [cloudpanel-io/clp-wp-varnish-cache](https://github.com/cloudpanel-io/clp-wp-varnish-cache) — the **CLP Varnish Cache Plugin** for **WordPress**, which lets you manage cache settings and perform purge operations.
 
 <p align="center">
   <a href="https://www.cloudpanel.io/docs/v2/frontend-area/varnish-cache/wordpress/plugin/" target="_blank">
@@ -6,13 +8,12 @@ With the plugin **CLP Varnish Cache Plugin** for **WordPress**, you can manage t
   </a>
 </p>
 
-## :sparkling_heart: Support This Project
+## Changes in this fork
 
-* Please star the project
-* Write about **CloudPanel** on platforms like **Twitter**, **Facebook** or **LinkedIn**
-* Follow us on [Twitter](https://twitter.com/cloudpanel_io) and retweet our tweets
-* Write a **Blog** post about **CloudPanel**
-* Give us [Feedback](https://www.cloudpanel.io/feedback/) to improve **CloudPanel**
-* Report [Bugs](https://github.com/cloudpanel-io/cloudpanel-ce/issues) on Github
-* Join our [Discord Server](https://discord.cloudpanel.io/)
-* [Get in touch with us](https://www.cloudpanel.io/contact/) if you have other ideas
+### 1.1.0
+
+- **Auto-purge on system updates** — Optionally clear the entire Varnish cache when WordPress core, a theme, or a plugin is updated. Controlled by a new checkbox in the plugin settings.
+
+### 1.0.4
+
+- **Fix fatal error when purging cache from admin bar** — `check_entire_cache_purge()` was called during plugin load, before `wp_get_current_user()` was available. The method is now hooked into `admin_init` instead. Fixes [upstream issue #15](https://github.com/cloudpanel-io/clp-wp-varnish-cache/issues/15).

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a fork of [cloudpanel-io/clp-wp-varnish-cache](https://github.com/cloudp
 
 ### 1.1.0
 
-- **Auto-purge on system updates** — Optionally clear the entire Varnish cache when WordPress core, a theme, or a plugin is updated. Controlled by a new checkbox in the plugin settings.
+- **Auto-purge on system updates** — Optionally clear the entire Varnish cache when WordPress core, a theme, or a plugin is updated. Controlled by a new checkbox in the plugin settings. Inspired by [upstream PR #5](https://github.com/cloudpanel-io/clp-wp-varnish-cache/pull/5) by [@filipmanzi](https://github.com/filipmanzi).
 
 ### 1.0.4
 

--- a/changelog
+++ b/changelog
@@ -1,3 +1,8 @@
+1.1.0 Thomas Barregren <thomas@kntnt.com> Fri, 07 Mar 2026
+- Add auto-purge of post/page/CPT URL on publish or update
+- Add auto-purge of entire cache on WP core, theme, or plugin updates
+- Add settings to toggle each auto-purge feature
+
 1.0.4 Thomas Barregren <thomas@kntnt.com> Fri, 07 Mar 2026
 - Fix fatal error when purging cache from admin bar (issue #15)
 

--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+1.0.4 Thomas Barregren <thomas@kntnt.com> Fri, 07 Mar 2026
+- Fix fatal error when purging cache from admin bar (issue #15)
+
 1.0.3 Stefan Wieczorek <stefan.wieczorek@cloudpanel.io> Tue, 17 Feb 2026 08:08:08
 - Fix CVE‑2026‑24525
 

--- a/changelog
+++ b/changelog
@@ -1,7 +1,6 @@
 1.1.0 Thomas Barregren <thomas@kntnt.com> Fri, 07 Mar 2026
-- Add auto-purge of post/page/CPT URL on publish or update
 - Add auto-purge of entire cache on WP core, theme, or plugin updates
-- Add settings to toggle each auto-purge feature
+- Add setting to toggle auto-purge feature
 
 1.0.4 Thomas Barregren <thomas@kntnt.com> Fri, 07 Mar 2026
 - Fix fatal error when purging cache from admin bar (issue #15)

--- a/class.varnish-cache-admin.php
+++ b/class.varnish-cache-admin.php
@@ -14,10 +14,10 @@ class ClpVarnishCacheAdmin {
         add_action('admin_menu', array($this, 'add_admin_menu'), 100);
         add_action('network_admin_menu', array($this, 'add_admin_menu'), 100);
         add_action('admin_enqueue_scripts', array($this, 'add_css'));
-        $this->check_entire_cache_purge();
+        add_action('admin_init', array($this, 'check_entire_cache_purge'));
     }
 
-    private function check_entire_cache_purge() {
+    public function check_entire_cache_purge() {
         if (true === isset($_GET['clp-varnish-cache']) && 'purge-entire-cache' == sanitize_text_field($_GET['clp-varnish-cache'])) {
             if (false === current_user_can('manage_options')) {                                   
                 return;                                                                           

--- a/class.varnish-cache-manager.php
+++ b/class.varnish-cache-manager.php
@@ -55,6 +55,22 @@ class ClpVarnishCacheManager {
         return $this->cache_settings;
     }
 
+    /**
+     * Check if cache should be cleared on WP core, theme, or plugin updates.
+     */
+    public function should_clear_on_updates(): bool {
+        $settings = $this->get_cache_settings();
+        return isset($settings['clearOnUpdates']) && $settings['clearOnUpdates'] === true;
+    }
+
+    /**
+     * Check if cache should be cleared when a post or page is saved.
+     */
+    public function should_clear_on_post_save(): bool {
+        $settings = $this->get_cache_settings();
+        return isset($settings['clearOnPostSave']) && $settings['clearOnPostSave'] === true;
+    }
+
     public function write_cache_settings(array $settings) {
         $settings_file = sprintf('%s/.varnish-cache/settings.json', rtrim(getenv('HOME'), '/'));
         $settings = json_encode($settings, JSON_PRETTY_PRINT);

--- a/class.varnish-cache-manager.php
+++ b/class.varnish-cache-manager.php
@@ -63,14 +63,6 @@ class ClpVarnishCacheManager {
         return isset($settings['clearOnUpdates']) && $settings['clearOnUpdates'] === true;
     }
 
-    /**
-     * Check if cache should be cleared when a post or page is saved.
-     */
-    public function should_clear_on_post_save(): bool {
-        $settings = $this->get_cache_settings();
-        return isset($settings['clearOnPostSave']) && $settings['clearOnPostSave'] === true;
-    }
-
     public function write_cache_settings(array $settings) {
         $settings_file = sprintf('%s/.varnish-cache/settings.json', rtrim(getenv('HOME'), '/'));
         $settings = json_encode($settings, JSON_PRETTY_PRINT);

--- a/clp-varnish-cache.php
+++ b/clp-varnish-cache.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: CLP Varnish Cache
  * Description: Varnish Cache Plugin by cloudpanel.io
- * Version: 1.0.4
+ * Version: 1.1.0
  * Text Domain: clp-varnish-cache
  * Domain Path: /languages
  * Requires at least: 6.0
@@ -18,12 +18,74 @@ if (false ===  function_exists('add_action')) {
     exit;
 }
 
-define('CLP_VARNISH_VERSION', '1.0.4');
+define('CLP_VARNISH_VERSION', '1.1.0');
+define('CLP_VARNISH_PLUGIN_DIR', plugin_dir_path(__FILE__));
+
+// Manager is needed for both admin and hook contexts.
+require_once CLP_VARNISH_PLUGIN_DIR . 'class.varnish-cache-manager.php';
+
 $is_admin = is_admin();
 
 if (true === $is_admin) {
-    define('CLP_VARNISH_PLUGIN_DIR', plugin_dir_path( __FILE__));
-    require_once CLP_VARNISH_PLUGIN_DIR . 'class.varnish-cache-manager.php';
     require_once CLP_VARNISH_PLUGIN_DIR . 'class.varnish-cache-admin.php';
     $clp_varnish_cache_admin = new ClpVarnishCacheAdmin();
 }
+
+/**
+ * Purge the specific post URL when published content is saved.
+ *
+ * @param int     $post_id Post ID.
+ * @param WP_Post $post    Post object.
+ * @param bool    $update  Whether this is an existing post being updated.
+ */
+function clp_varnish_purge_on_post_save(int $post_id, WP_Post $post, bool $update): void {
+    // Ignore autosaves and revisions.
+    if (wp_is_post_autosave($post_id) || wp_is_post_revision($post_id)) {
+        return;
+    }
+
+    // Only purge published, public post types.
+    if ($post->post_status !== 'publish') {
+        return;
+    }
+    $post_type_object = get_post_type_object($post->post_type);
+    if ($post_type_object === null || $post_type_object->public !== true) {
+        return;
+    }
+
+    $manager = new ClpVarnishCacheManager();
+    if ($manager->is_enabled() === false || $manager->should_clear_on_post_save() === false) {
+        return;
+    }
+
+    $url = get_permalink($post_id);
+    if (false === empty($url)) {
+        $manager->purge_url($url);
+    }
+}
+add_action('save_post', 'clp_varnish_purge_on_post_save', 20, 3);
+
+/**
+ * Purge the entire host cache after WP core, theme, or plugin updates.
+ *
+ * @param WP_Upgrader $upgrader Upgrader instance.
+ * @param array       $options  Update details.
+ */
+function clp_varnish_purge_on_update(WP_Upgrader $upgrader, array $options): void {
+    if ($options['action'] !== 'update') {
+        return;
+    }
+
+    $manager = new ClpVarnishCacheManager();
+    if ($manager->is_enabled() === false || $manager->should_clear_on_updates() === false) {
+        return;
+    }
+
+    $site_url = get_site_url();
+    $parsed = parse_url($site_url);
+    $host = $parsed['host'] ?? '';
+    if (false === empty($host)) {
+        $manager->purge_host($host);
+    }
+}
+add_action('upgrader_process_complete', 'clp_varnish_purge_on_update', 10, 2);

--- a/clp-varnish-cache.php
+++ b/clp-varnish-cache.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: CLP Varnish Cache
  * Description: Varnish Cache Plugin by cloudpanel.io
- * Version: 1.0.3
+ * Version: 1.0.4
  * Text Domain: clp-varnish-cache
  * Domain Path: /languages
  * Requires at least: 6.0
@@ -18,7 +18,7 @@ if (false ===  function_exists('add_action')) {
     exit;
 }
 
-define('CLP_VARNISH_VERSION', '1.0.3');
+define('CLP_VARNISH_VERSION', '1.0.4');
 $is_admin = is_admin();
 
 if (true === $is_admin) {

--- a/clp-varnish-cache.php
+++ b/clp-varnish-cache.php
@@ -32,40 +32,6 @@ if (true === $is_admin) {
 }
 
 /**
- * Purge the specific post URL when published content is saved.
- *
- * @param int     $post_id Post ID.
- * @param WP_Post $post    Post object.
- * @param bool    $update  Whether this is an existing post being updated.
- */
-function clp_varnish_purge_on_post_save(int $post_id, WP_Post $post, bool $update): void {
-    // Ignore autosaves and revisions.
-    if (wp_is_post_autosave($post_id) || wp_is_post_revision($post_id)) {
-        return;
-    }
-
-    // Only purge published, public post types.
-    if ($post->post_status !== 'publish') {
-        return;
-    }
-    $post_type_object = get_post_type_object($post->post_type);
-    if ($post_type_object === null || $post_type_object->public !== true) {
-        return;
-    }
-
-    $manager = new ClpVarnishCacheManager();
-    if ($manager->is_enabled() === false || $manager->should_clear_on_post_save() === false) {
-        return;
-    }
-
-    $url = get_permalink($post_id);
-    if (false === empty($url)) {
-        $manager->purge_url($url);
-    }
-}
-add_action('save_post', 'clp_varnish_purge_on_post_save', 20, 3);
-
-/**
  * Purge the entire host cache after WP core, theme, or plugin updates.
  *
  * @param WP_Upgrader $upgrader Upgrader instance.

--- a/pages/clp-varnish-cache.php
+++ b/pages/clp-varnish-cache.php
@@ -22,14 +22,18 @@ if (true === isset($_POST['action']) && 'save-settings' == sanitize_text_field($
     $excluded_params = array_map('trim', array_filter(explode(',', getPostValue('excluded-params'))));
     $excludes = (true === isset($_POST['excludes']) ? sanitize_textarea_field($_POST['excludes']) : '');
     $excludes = array_map('trim', array_filter(explode(PHP_EOL, $excludes)));
+    $clear_on_updates = (1 == getPostValue('clear-on-updates') ? true : false);
+    $clear_on_post_save = (1 == getPostValue('clear-on-post-save') ? true : false);
     if (false === empty($server) && false === empty($cache_lifetime) && false === empty($cache_tag_prefix)) {
         $cache_settings = [
-            'enabled'        => $enabled,
-            'server'         => $server,
-            'cacheTagPrefix' => $cache_tag_prefix,
-            'cacheLifetime'  => $cache_lifetime,
-            'excludes'       => $excludes,
-            'excludedParams' => $excluded_params,
+            'enabled'         => $enabled,
+            'server'          => $server,
+            'cacheTagPrefix'  => $cache_tag_prefix,
+            'cacheLifetime'   => $cache_lifetime,
+            'excludes'        => $excludes,
+            'excludedParams'  => $excluded_params,
+            'clearOnUpdates'  => $clear_on_updates,
+            'clearOnPostSave' => $clear_on_post_save,
         ];
         $clp_cache_manager->write_cache_settings($cache_settings);
         $clp_cache_manager->reset_cache_settings();
@@ -80,6 +84,8 @@ $cache_lifetime = $clp_cache_manager->get_cache_lifetime();
 $cache_tag_prefix = $clp_cache_manager->get_cache_tag_prefix();
 $excluded_params = $clp_cache_manager->get_excluded_params();
 $excludes = $clp_cache_manager->get_excludes();
+$clear_on_updates = $clp_cache_manager->should_clear_on_updates();
+$clear_on_post_save = $clp_cache_manager->should_clear_on_post_save();
 
 ?>
 <h1 id="clp-varnish-cache"><?php esc_html_e( 'CLP Varnish Cache', 'clp-varnish-cache' ); ?></h1>
@@ -154,6 +160,24 @@ $excludes = $clp_cache_manager->get_excludes();
                   <td>
                     <textarea name="excludes" rows="6"><?php echo esc_textarea($excludes); ?></textarea>
                     <p class="description"><?php esc_html_e( 'Urls and files that Varnish Cache shouldn\'t cache.', 'clp-varnish-cache' ); ?></p>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="field-name">
+                    <?php esc_html_e( 'Clear cache on updates', 'clp-varnish-cache' ); ?>:
+                  </td>
+                  <td>
+                    <input type="checkbox" name="clear-on-updates" <?php echo (true === $clear_on_updates ? 'checked' : ''); ?> value="1" />
+                    <p class="description"><?php esc_html_e( 'Automatically clear the entire cache when WordPress core, a theme, or a plugin is updated.', 'clp-varnish-cache' ); ?></p>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="field-name">
+                    <?php esc_html_e( 'Clear cache on post save', 'clp-varnish-cache' ); ?>:
+                  </td>
+                  <td>
+                    <input type="checkbox" name="clear-on-post-save" <?php echo (true === $clear_on_post_save ? 'checked' : ''); ?> value="1" />
+                    <p class="description"><?php esc_html_e( 'Automatically clear the cache of a post, page, or custom post type when it is published or updated.', 'clp-varnish-cache' ); ?></p>
                   </td>
                 </tr>
               </tbody>

--- a/pages/clp-varnish-cache.php
+++ b/pages/clp-varnish-cache.php
@@ -23,7 +23,6 @@ if (true === isset($_POST['action']) && 'save-settings' == sanitize_text_field($
     $excludes = (true === isset($_POST['excludes']) ? sanitize_textarea_field($_POST['excludes']) : '');
     $excludes = array_map('trim', array_filter(explode(PHP_EOL, $excludes)));
     $clear_on_updates = (1 == getPostValue('clear-on-updates') ? true : false);
-    $clear_on_post_save = (1 == getPostValue('clear-on-post-save') ? true : false);
     if (false === empty($server) && false === empty($cache_lifetime) && false === empty($cache_tag_prefix)) {
         $cache_settings = [
             'enabled'         => $enabled,
@@ -33,7 +32,6 @@ if (true === isset($_POST['action']) && 'save-settings' == sanitize_text_field($
             'excludes'        => $excludes,
             'excludedParams'  => $excluded_params,
             'clearOnUpdates'  => $clear_on_updates,
-            'clearOnPostSave' => $clear_on_post_save,
         ];
         $clp_cache_manager->write_cache_settings($cache_settings);
         $clp_cache_manager->reset_cache_settings();
@@ -85,7 +83,6 @@ $cache_tag_prefix = $clp_cache_manager->get_cache_tag_prefix();
 $excluded_params = $clp_cache_manager->get_excluded_params();
 $excludes = $clp_cache_manager->get_excludes();
 $clear_on_updates = $clp_cache_manager->should_clear_on_updates();
-$clear_on_post_save = $clp_cache_manager->should_clear_on_post_save();
 
 ?>
 <h1 id="clp-varnish-cache"><?php esc_html_e( 'CLP Varnish Cache', 'clp-varnish-cache' ); ?></h1>
@@ -169,15 +166,6 @@ $clear_on_post_save = $clp_cache_manager->should_clear_on_post_save();
                   <td>
                     <input type="checkbox" name="clear-on-updates" <?php echo (true === $clear_on_updates ? 'checked' : ''); ?> value="1" />
                     <p class="description"><?php esc_html_e( 'Automatically clear the entire cache when WordPress core, a theme, or a plugin is updated.', 'clp-varnish-cache' ); ?></p>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="field-name">
-                    <?php esc_html_e( 'Clear cache on post save', 'clp-varnish-cache' ); ?>:
-                  </td>
-                  <td>
-                    <input type="checkbox" name="clear-on-post-save" <?php echo (true === $clear_on_post_save ? 'checked' : ''); ?> value="1" />
-                    <p class="description"><?php esc_html_e( 'Automatically clear the cache of a post, page, or custom post type when it is published or updated.', 'clp-varnish-cache' ); ?></p>
                   </td>
                 </tr>
               </tbody>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: varnish, varnish cache, cache, caching
 Requires at least: 6.0
 Tested up to: 6.9.1
 Requires PHP: 7.1
-Stable tag: 1.0.4
+Stable tag: 1.1.0
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 SVN Repository: http://plugins.svn.wordpress.org/clp-varnish-cache/

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: varnish, varnish cache, cache, caching
 Requires at least: 6.0
 Tested up to: 6.9.1
 Requires PHP: 7.1
-Stable tag: 1.0.3
+Stable tag: 1.0.4
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 SVN Repository: http://plugins.svn.wordpress.org/clp-varnish-cache/


### PR DESCRIPTION
## Summary

- Hooks `check_entire_cache_purge()` into `admin_init` instead of calling it directly during plugin load, when `wp_get_current_user()` is not yet available.
- Changes method visibility from `private` to `public` so WordPress hooks can invoke it via `call_user_func_array()`.

Fixes #15