### PR TITLE
Move cache check into `admin_init` to ensure `get_current_user` is available

### DIFF
--- a/class.varnish-cache-admin.php
+++ b/class.varnish-cache-admin.php
@@ -10,14 +10,14 @@ class ClpVarnishCacheAdmin {
     }
 
     public function init() {
+        add_action('admin_init', array($this, 'check_entire_cache_purge'), 100);
         add_action('admin_bar_menu', array($this, 'add_adminbar'), 100);
         add_action('admin_menu', array($this, 'add_admin_menu'), 100);
         add_action('network_admin_menu', array($this, 'add_admin_menu'), 100);
         add_action('admin_enqueue_scripts', array($this, 'add_css'));
-        $this->check_entire_cache_purge();
     }
 
-    private function check_entire_cache_purge() {
+    public function check_entire_cache_purge() {
         if (true === isset($_GET['clp-varnish-cache']) && 'purge-entire-cache' == sanitize_text_field($_GET['clp-varnish-cache'])) {
             if (false === current_user_can('manage_options')) {                                   
                 return;                                                                           


### PR DESCRIPTION
# Fatal WordPress Error fix

Resolves #15 - an error raised by calling `get_current_user()` too early in the request lifecycle.

<img width="965" height="293" alt="image" src="https://github.com/user-attachments/assets/e5fcfcd7-c0f1-4e14-8dd2-7c1bee832b14" />

* Moved `$this->check_entire_cache_purge()` into an `admin_init` action.
* I have verified that this fix works on one of our staging sites.
* _I'm aware of the open PR (16) that that resolves this, however, this PR fixes the problem without any additional functionality changes._

I'm happy to be responsive on this, as getting this fix through would be great for us!