### PR TITLE
Purge cache on state changing actions

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+[nix]
+packages = ["zip"]

--- a/bin/create-release
+++ b/bin/create-release
@@ -1,13 +1,42 @@
 #!/bin/bash
-VERSION='1.0.1'
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}===> Starting Build Process...${NC}"
+
+VERSION=$(grep "define('CLP_VARNISH_VERSION'" ../clp-varnish-cache.php | awk -F"'" '{print $4}')
+
+if [ -z "$VERSION" ]; then
+    echo -e "${RED}✖ Error: Could not find CLP_VARNISH_VERSION in ../clp-varnish-cache.php${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✔ Found Version: ${YELLOW}$VERSION${NC}\n"
+
+echo -e "${BLUE}===> Preparing temporary directories...${NC}"
 TMP_DIRECTORY='tmp'
 TMP_RELEASE_DIRECTORY='tmp/clp-varnish-cache/'
+
 rm -rf $TMP_DIRECTORY
 mkdir -p $TMP_RELEASE_DIRECTORY
-cp -R ../* $TMP_RELEASE_DIRECTORY
+
+# Copy files & silence the "cannot copy directory into itself" error
+cp -R ../* $TMP_RELEASE_DIRECTORY 2>/dev/null
+
 rm -rf $TMP_RELEASE_DIRECTORY/bin/
 rm -rf $TMP_RELEASE_DIRECTORY/release/
-rm $TMP_RELEASE_DIRECTORY/languages/*.po~
+rm -f $TMP_RELEASE_DIRECTORY/languages/*.po~ 2>/dev/null
+
+echo -e "${BLUE}===> Creating zip archive...${NC}"
 cd $TMP_DIRECTORY
-zip -r "clp-varnish-cache-$VERSION.zip" clp-varnish-cache
+
+# '-q' (quiet) flag to stop 'zip' from spamming the console
+zip -qr "clp-varnish-cache-$VERSION.zip" clp-varnish-cache
 rm -rf clp-varnish-cache
+
+echo -e "\n${GREEN}✔ Success! Release packaged successfully.${NC}"
+echo -e "📁 ${YELLOW}bin/tmp/clp-varnish-cache-$VERSION.zip${NC}\n"

--- a/class.varnish-cache-auto-purge.php
+++ b/class.varnish-cache-auto-purge.php
@@ -1,0 +1,29 @@
+<?php
+
+class ClpVarnishCacheAutoPurge {
+
+    public function __construct() {
+        add_action( 'upgrader_process_complete', array( $this, 'auto_purge' ), 10, 2 );
+        add_action( 'deactivated_plugin', array( $this, 'auto_purge' ) );
+        add_action( 'activated_plugin', array( $this, 'auto_purge' ) );
+        add_action( 'switch_theme', array( $this, 'auto_purge' ) );
+    }
+
+    public function auto_purge( $upgrader_or_plugin = null, $options = null ) {
+        if ( current_action() === 'upgrader_process_complete' ) {
+            if ( empty( $options['action'] ) || $options['action'] !== 'update' ) return;
+            if ( empty( $options['type'] ) || ! in_array( $options['type'], ['plugin', 'theme', 'core'], true ) ) return;
+        }
+
+        if ( ! class_exists( 'ClpVarnishCacheManager' ) ) return;
+        $manager = new ClpVarnishCacheManager();
+
+        if ( ! $manager->is_enabled() ) return;
+
+        $host = wp_parse_url( home_url(), PHP_URL_HOST );
+        if ( ! empty( $host ) ) $manager->purge_host( $host );
+
+        $prefix = $manager->get_cache_tag_prefix();
+        if ( ! empty( $prefix ) ) $manager->purge_tag( $prefix );
+    }
+}

--- a/clp-varnish-cache.php
+++ b/clp-varnish-cache.php
@@ -2,7 +2,7 @@
 /*
  * Plugin Name: CLP Varnish Cache
  * Description: Varnish Cache Plugin by cloudpanel.io
- * Version: 1.0.3
+ * Version: 1.1.0
  * Text Domain: clp-varnish-cache
  * Domain Path: /languages
  * Requires at least: 6.0
@@ -18,12 +18,14 @@ if (false ===  function_exists('add_action')) {
     exit;
 }
 
-define('CLP_VARNISH_VERSION', '1.0.3');
+define('CLP_VARNISH_VERSION', '1.1.0');
 $is_admin = is_admin();
 
 if (true === $is_admin) {
     define('CLP_VARNISH_PLUGIN_DIR', plugin_dir_path( __FILE__));
     require_once CLP_VARNISH_PLUGIN_DIR . 'class.varnish-cache-manager.php';
     require_once CLP_VARNISH_PLUGIN_DIR . 'class.varnish-cache-admin.php';
+    require_once CLP_VARNISH_PLUGIN_DIR . 'class.varnish-cache-auto-purge.php';
+    $clp_varnish_cache_auto_purge = new ClpVarnishCacheAutoPurge();
     $clp_varnish_cache_admin = new ClpVarnishCacheAdmin();
 }


### PR DESCRIPTION
Improve release script.
Add compatibility for Replit IDE.

Purges cache on:
- plugin, theme, core update
- plugin deactivate
- plugin activate
- theme switch

Resolves #4 