### PR TITLE
refactor: centralize cache purge logic and patch csrf vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,45 @@
-With the plugin **CLP Varnish Cache Plugin** for **WordPress**, you can manage the cache settings and perform purge operations.
+# CLP Varnish Cache Plugin for WordPress
+
+With the **CLP Varnish Cache Plugin** for WordPress, you can easily manage your Varnish cache settings and perform purge operations directly from your WordPress admin dashboard or admin bar.
 
 <p align="center">
   <a href="https://www.cloudpanel.io/docs/v2/frontend-area/varnish-cache/wordpress/plugin/" target="_blank">
-    <img src="/release/plugin.png?v=0.0.1">
+    <img src="/release/plugin.png?v=0.0.1" alt="CLP Varnish Cache Plugin">
   </a>
 </p>
 
-## :sparkling_heart: Support This Project
+## Features
 
-* Please star the project
+* **Auto-Purging:** Automatically purges the cache when updating content.
+* **Cache Lifetime:** Define how long items should live in the Varnish cache before being refreshed.
+* **Custom Exclusions:** Configure custom URL paths and GET parameters to exclude from the cache.
+* **Manual Purging:** Easily purge the entire cache, specific URLs, or cache tags via the WordPress admin settings or the admin bar.
+
+## 💻 For Developers: Hooking into the Plugin
+
+If you are writing custom plugins, themes, or using a tool like Code Snippets, you can easily hook into the `ClpVarnishCacheManager` to clear the cache programmatically.
+
+Here are a few examples of how to utilize the manager class:
+
+```php
+// First, make sure the class is available
+if (class_exists('ClpVarnishCacheManager')) {
+    $varnish_manager = new ClpVarnishCacheManager();
+
+    // purge the entire cache
+    $varnish_manager->purge_entire_cache();
+
+    // or purge a specific URL
+    $varnish_manager->purge_url('https://www.yourdomain.com/specific-page/');
+
+    // or purge a specific cache tag
+    $varnish_manager->purge_tag('my_custom_tag');
+}
+```
+
+## Support This Project
+
+* Please star the project on GitHub
 * Write about **CloudPanel** on platforms like **Twitter**, **Facebook** or **LinkedIn**
 * Follow us on [Twitter](https://twitter.com/cloudpanel_io) and retweet our tweets
 * Write a **Blog** post about **CloudPanel**

--- a/changelog
+++ b/changelog
@@ -1,4 +1,10 @@
-1.1.0 Stefan Wieczorek <stefan.wieczorek@cloudpanel.io> Tue, 17 Mar 2026 08:08:08
+1.1.2 Stefan Wieczorek <stefan.wieczorek@cloudpanel.io> Thu, 19 Mar 2026 08:08:08
+- #20 Security patch and stability improvements (Thanks to 7heMech)
+  • Added nonces to patch CSRF vulnerabilities on settings and purge actions
+  • Restored full compatibility with PHP 7.1
+  • Improved cache purging logic and enhanced error handling
+
+1.1.1 Stefan Wieczorek <stefan.wieczorek@cloudpanel.io> Tue, 17 Mar 2026 08:08:08
 - #18 Automatically purge cache after plugin/theme updates: (Thanks to 7heMech)
   • Core upgrade
   • Activating or deactivating plugins

--- a/changelog
+++ b/changelog
@@ -1,8 +1,9 @@
 1.1.2 Stefan Wieczorek <stefan.wieczorek@cloudpanel.io> Thu, 19 Mar 2026 08:08:08
 - #20 Security patch and stability improvements (Thanks to 7heMech)
   • Added nonces to patch CSRF vulnerabilities on settings and purge actions
-  • Restored full compatibility with PHP 7.1
   • Improved cache purging logic and enhanced error handling
+  • Restored full compatibility with PHP 7.1
+  • Improved UI/UX
 
 1.1.1 Stefan Wieczorek <stefan.wieczorek@cloudpanel.io> Tue, 17 Mar 2026 08:08:08
 - #18 Automatically purge cache after plugin/theme updates: (Thanks to 7heMech)

--- a/class.varnish-cache-admin.php
+++ b/class.varnish-cache-admin.php
@@ -25,14 +25,7 @@ class ClpVarnishCacheAdmin {
             if (false === isset($_GET['_wpnonce']) || false === wp_verify_nonce(sanitize_text_field($_GET['_wpnonce']), 'purge-entire-cache')) {
                 return;                                                                           
             }   
-            $host = (true === isset($_SERVER['HTTP_HOST']) && false === empty(sanitize_text_field($_SERVER['HTTP_HOST'])) ? sanitize_text_field($_SERVER['HTTP_HOST']) : '');
-            if (false === empty($host)) {
-                $this->clp_varnish_cache_manager->purge_host($host);
-            }
-            $cache_tag_prefix = $this->clp_varnish_cache_manager->get_cache_tag_prefix();
-            if (false === empty($cache_tag_prefix)) {
-                $this->clp_varnish_cache_manager->purge_tag($cache_tag_prefix);
-            }
+            $this->clp_varnish_cache_manager->purge_entire_cache();
             add_action('admin_notices', array( $this, 'admin_entire_cache_purge'));
         }
     }

--- a/class.varnish-cache-admin.php
+++ b/class.varnish-cache-admin.php
@@ -10,28 +10,24 @@ class ClpVarnishCacheAdmin {
     }
 
     public function init() {
-        add_action('admin_init', array($this, 'check_entire_cache_purge'), 100);
-        add_action('admin_bar_menu', array($this, 'add_adminbar'), 100);
-        add_action('admin_menu', array($this, 'add_admin_menu'), 100);
-        add_action('network_admin_menu', array($this, 'add_admin_menu'), 100);
-        add_action('admin_enqueue_scripts', array($this, 'add_css'));
+        add_action('admin_init', [$this, 'check_entire_cache_purge'], 100);
+        add_action('admin_bar_menu', [$this, 'add_adminbar'], 100);
+        add_action('admin_menu', [$this, 'add_admin_menu'], 100);
+        add_action('network_admin_menu', [$this, 'add_admin_menu'], 100);
+        add_action('admin_enqueue_scripts', [$this, 'add_css']);
     }
 
     public function check_entire_cache_purge() {
-        if (true === isset($_GET['clp-varnish-cache']) && 'purge-entire-cache' == sanitize_text_field($_GET['clp-varnish-cache'])) {
-            if (false === current_user_can('manage_options')) {                                   
-                return;                                                                           
-            }                                                                                     
-            if (false === isset($_GET['_wpnonce']) || false === wp_verify_nonce(sanitize_text_field($_GET['_wpnonce']), 'purge-entire-cache')) {
-                return;                                                                           
-            }   
-            $this->clp_varnish_cache_manager->purge_entire_cache();
-            add_action('admin_notices', array( $this, 'admin_entire_cache_purge'));
-        }
+        if (!isset($_GET['_wpnonce']) || !wp_verify_nonce(sanitize_text_field($_GET['_wpnonce']), 'purge-entire-cache')) return;
+        if (!isset($_GET['clp-varnish-cache']) || sanitize_text_field($_GET['clp-varnish-cache']) !== 'purge-entire-cache') return;
+        if (!current_user_can('manage_options')) return;
+
+        $this->clp_varnish_cache_manager->purge_entire_cache();
+        add_action('admin_notices', [$this, 'admin_entire_cache_purge']);
     }
 
     public function admin_entire_cache_purge() {
-        echo '<div id="noice" class="notice notice-success fade is-dismissible"><p><strong>' . esc_html__( 'Varnish Cache has been purged.', 'clp-varnish-cache' ) . '</strong></p></div>';
+        echo '<div id="notice" class="notice notice-success fade is-dismissible"><p><strong>' . esc_html__('Varnish Cache has been purged.', 'clp-varnish-cache') . '</strong></p></div>';
     }
 
     public function get_clp_cache_manager() {
@@ -39,108 +35,78 @@ class ClpVarnishCacheAdmin {
     }
 
     public function add_adminbar($adminbar) {
-        $is_admin = is_admin();
-        if (true === $is_admin && true === current_user_can( 'edit_published_posts' )) {
-            $varnish_cache_settings = $this->clp_varnish_cache_manager->get_cache_settings();
-            if (false === empty($varnish_cache_settings)) {
-                $menu_title = __( 'CLP Varnish Cache', 'clp-varnish-cache');
-                $is_network = is_multisite() && is_network_admin();
-                $admin_bar_nodes = [
-                    [
-                        'id'    => 'clp-varnish-cache',
-                        'title' => '<span class="ab-icon" style="background-image: url(' . self::get_svg_icon() . ') !important;"></span><span class="ab-label">' . $menu_title . '</span>',
-                        'meta'  => [
-                            'class' => 'clp-varnish-cache',
-                        ],
-                    ],
-                    [
-                        'parent' => 'clp-varnish-cache',
-                        'id'     => 'clp-varnish-cache-purge',
-                        'title'  => __( 'Purge', 'clp-varnish-cache' ),
-                        'meta'   => [ 'tabindex' => '0' ],
-                    ],
-                    [
-                        'parent' => 'clp-varnish-cache-purge',
-                        'id'     => 'clp-varnish-cache-purge-entire-cache',
-                        'title'  => __( 'Entire Cache', 'clp-varnish-cache' ),
-                        'href'   => wp_nonce_url(add_query_arg('clp-varnish-cache', 'purge-entire-cache'), 'purge-entire-cache'),
-                        'meta'   => [
-                            'title' => __( 'Entire Cache', 'clp-varnish-cache' ),
-                        ],
-                    ],
-                    [
-                        'parent' => 'clp-varnish-cache-purge',
-                        'id'     => 'clp-varnish-cache-purge-tags-urls',
-                        'title'  => __( 'Cache Tags and Urls', 'clp-varnish-cache' ),
-                        'href'   => (true === $is_network ? network_admin_url('settings.php?page=clp-varnish-cache') : admin_url('options-general.php?page=clp-varnish-cache')),
-                        'meta'   => [
-                            'title' => __( 'Cache Tags and Urls', 'clp-varnish-cache' ),
-                        ],
-                    ],
-                    [
-                        'parent' => 'clp-varnish-cache',
-                        'id'     => 'clp-varnish-cache-enable',
-                        'title'  => __( 'Settings', 'clp-varnish-cache' ),
-                        'href'   => (true === $is_network ? network_admin_url('settings.php?page=clp-varnish-cache') : admin_url('options-general.php?page=clp-varnish-cache')),
-                        'meta'   => [ 'tabindex' => '0' ],
-                    ],
-                ];
-                foreach ($admin_bar_nodes as $node) {
-                    $adminbar->add_node($node);
-                }
-            }
-        }
+        if (!is_admin() || !current_user_can('edit_published_posts')) return;
+        if (empty($this->clp_varnish_cache_manager->get_cache_settings())) return;
+
+        $menu_title = __('CLP Varnish Cache', 'clp-varnish-cache');
+        $is_network = is_multisite() && is_network_admin();
+        $base_url = $is_network ? network_admin_url('settings.php?page=clp-varnish-cache') : admin_url('options-general.php?page=clp-varnish-cache');
+
+        $admin_bar_nodes = [
+            [
+                'id'    => 'clp-varnish-cache',
+                'title' => '<span class="ab-icon" style="background-image: url(' . self::get_svg_icon() . ') !important;"></span><span class="ab-label">' . $menu_title . '</span>',
+                'meta'  => ['class' => 'clp-varnish-cache'],
+            ],
+            [
+                'parent' => 'clp-varnish-cache',
+                'id'     => 'clp-varnish-cache-purge',
+                'title'  => __('Purge', 'clp-varnish-cache'),
+                'meta'   => ['tabindex' => '0'],
+            ],
+            [
+                'parent' => 'clp-varnish-cache-purge',
+                'id'     => 'clp-varnish-cache-purge-entire-cache',
+                'title'  => __('Entire Cache', 'clp-varnish-cache'),
+                'href'   => wp_nonce_url(add_query_arg('clp-varnish-cache', 'purge-entire-cache'), 'purge-entire-cache'),
+                'meta'   => ['title' => __('Entire Cache', 'clp-varnish-cache')],
+            ],
+            [
+                'parent' => 'clp-varnish-cache-purge',
+                'id'     => 'clp-varnish-cache-purge-tags-urls',
+                'title'  => __('Cache Tags and Urls', 'clp-varnish-cache'),
+                'href'   => $base_url,
+                'meta'   => ['title' => __('Cache Tags and Urls', 'clp-varnish-cache')],
+            ],
+            [
+                'parent' => 'clp-varnish-cache',
+                'id'     => 'clp-varnish-cache-enable',
+                'title'  => __('Settings', 'clp-varnish-cache'),
+                'href'   => $base_url,
+                'meta'   => ['tabindex' => '0'],
+            ],
+        ];
+
+        foreach ($admin_bar_nodes as $node) $adminbar->add_node($node);
     }
 
     public function add_admin_menu() {
         $is_network = is_multisite() && is_network_admin();
-        if (true === $is_network) {
-            add_submenu_page(
-                'settings.php',
-                __( 'CLP Varnish Cache', 'clp-varnish-cache' ),
-                __( 'CLP Varnish Cache', 'clp-varnish-cache' ),
-                'manage_options',
-                'clp-varnish-cache',
-                array( &$this, 'clp_varnish_cache_page' )
-            );
-        } else {
-            add_submenu_page(
-                'options-general.php',
-                __( 'CLP Varnish Cache', 'clp-varnish-cache' ),
-                __( 'CLP Varnish Cache', 'clp-varnish-cache' ),
-                'manage_options',
-                'clp-varnish-cache',
-                array( &$this, 'clp_varnish_cache_page' )
-            );
-        }
+        $parent_slug = $is_network ? 'settings.php' : 'options-general.php';
+
+        add_submenu_page(
+            $parent_slug,
+            __('CLP Varnish Cache', 'clp-varnish-cache'),
+            __('CLP Varnish Cache', 'clp-varnish-cache'),
+            'manage_options',
+            'clp-varnish-cache',
+            [$this, 'clp_varnish_cache_page']
+        );
     }
 
     public function clp_varnish_cache_page() {
-        $plugin_dir_path = plugin_dir_path( __FILE__ );
-        $varnish_cache_page_path = sprintf('%s/pages/clp-varnish-cache.php', rtrim($plugin_dir_path, '/'));
-        include $varnish_cache_page_path;
+        include rtrim(plugin_dir_path(__FILE__), '/') . '/pages/clp-varnish-cache.php';
     }
 
     public function add_css() {
-        if (true === is_user_logged_in() && true === is_admin_bar_showing() ) {
-            wp_register_style('clp-varnish-cache', plugins_url('style.css', __FILE__), false, CLP_VARNISH_VERSION);
-            wp_enqueue_style('clp-varnish-cache');
-        }
+        if (!is_user_logged_in() || !is_admin_bar_showing()) return;
+
+        wp_register_style('clp-varnish-cache', plugins_url('style.css', __FILE__), false, CLP_VARNISH_VERSION);
+        wp_enqueue_style('clp-varnish-cache');
     }
 
     public static function get_svg_icon($base64 = true, $icon_color = false) {
-        global $_wp_admin_css_colors;
-        $fill = ( false !== $icon_color ) ? sanitize_hex_color( $icon_color ) : '#82878c';
-        if (true === is_admin() && false === $icon_color && get_user_option('admin_color') ) {
-            $admin_colors  = json_decode(wp_json_encode($_wp_admin_css_colors), true);
-            $current_color = get_user_option( 'admin_color' );
-            $fill          = $admin_colors[$current_color ]['icon_colors']['base'];
-        }
-        $fill = '#006ad0';
-        $svg = '<svg width="100%" viewBox="0 5 20 20" xmlns="http://www.w3.org/2000/svg"><path fill="' . $fill . '" d="m15.676002,13.634a4.959,4.959 0 0 0 -2.363,-1.649l0,-0.06c0,-2.823 -2.208,-5.124 -4.93,-5.124c-2.724,0 -4.933,2.296 -4.933,5.125l0,0.07c-1.994,0.653 -3.45,2.595 -3.45,4.886c0,2.823 2.21,5.125 4.932,5.125a4.832,4.832 0 0 0 3.465,-1.475a4.817,4.817 0 0 0 3.461,1.475c2.717,0 4.933,-2.296 4.933,-5.125c0,-1.18 -0.4,-2.334 -1.115,-3.248zm-3.818,7.077c-2.031,0 -3.685,-1.718 -3.685,-3.83a0.637,0.637 0 0 0 -0.623,-0.646a0.634,0.634 0 0 0 -0.624,0.647c0,0.957 0.257,1.855 0.696,2.622a3.607,3.607 0 0 1 -2.69,1.213c-2.032,0 -3.687,-1.719 -3.687,-3.83c0,-2.11 1.655,-3.829 3.687,-3.829c0.44,0 0.868,0.082 1.278,0.234c0.005,0 0.009,0.005 0.014,0.005c0.142,0.05 0.342,0.147 0.404,0.201a0.6,0.6 0 0 0 0.874,-0.07a0.659,0.659 0 0 0 -0.068,-0.91c-0.272,-0.239 -0.696,-0.402 -0.8,-0.44a4.767,4.767 0 0 0 -1.697,-0.31c-0.079,0 -0.157,0 -0.236,0.005c0.084,-2.04 1.702,-3.671 3.687,-3.671c2.031,0 3.685,1.718 3.685,3.83a3.896,3.896 0 0 1 -1.55,3.122a0.663,0.663 0 0 0 -0.147,0.898c0.12,0.174 0.315,0.272 0.509,0.272c0.125,0 0.25,-0.038 0.361,-0.12a5.164,5.164 0 0 0 1.895,-2.812c1.424,0.549 2.413,1.979 2.413,3.595c-0.005,2.106 -1.659,3.824 -3.696,3.824z"/></svg>';
-        if (true === $base64) {
-            return 'data:image/svg+xml;base64,' . base64_encode($svg);
-        }
-        return $svg;
+        $svg = '<svg width="100%" viewBox="0 5 20 20" xmlns="http://www.w3.org/2000/svg"><path fill="#006ad0" d="m15.676002,13.634a4.959,4.959 0 0 0 -2.363,-1.649l0,-0.06c0,-2.823 -2.208,-5.124 -4.93,-5.124c-2.724,0 -4.933,2.296 -4.933,5.125l0,0.07c-1.994,0.653 -3.45,2.595 -3.45,4.886c0,2.823 2.21,5.125 4.932,5.125a4.832,4.832 0 0 0 3.465,-1.475a4.817,4.817 0 0 0 3.461,1.475c2.717,0 4.933,-2.296 4.933,-5.125c0,-1.18 -0.4,-2.334 -1.115,-3.248zm-3.818,7.077c-2.031,0 -3.685,-1.718 -3.685,-3.83a0.637,0.637 0 0 0 -0.623,-0.646a0.634,0.634 0 0 0 -0.624,0.647c0,0.957 0.257,1.855 0.696,2.622a3.607,3.607 0 0 1 -2.69,1.213c-2.032,0 -3.687,-1.719 -3.687,-3.83c0,-2.11 1.655,-3.829 3.687,-3.829c0.44,0 0.868,0.082 1.278,0.234c0.005,0 0.009,0.005 0.014,0.005c0.142,0.05 0.342,0.147 0.404,0.201a0.6,0.6 0 0 0 0.874,-0.07a0.659,0.659 0 0 0 -0.068,-0.91c-0.272,-0.239 -0.696,-0.402 -0.8,-0.44a4.767,4.767 0 0 0 -1.697,-0.31c-0.079,0 -0.157,0 -0.236,0.005c0.084,-2.04 1.702,-3.671 3.687,-3.671c2.031,0 3.685,1.718 3.685,3.83a3.896,3.896 0 0 1 -1.55,3.122a0.663,0.663 0 0 0 -0.147,0.898c0.12,0.174 0.315,0.272 0.509,0.272c0.125,0 0.25,-0.038 0.361,-0.12a5.164,5.164 0 0 0 1.895,-2.812c1.424,0.549 2.413,1.979 2.413,3.595c-0.005,2.106 -1.659,3.824 -3.696,3.824z"/></svg>';
+        return $base64 ? 'data:image/svg+xml;base64,' . base64_encode($svg) : $svg;
     }
 }

--- a/class.varnish-cache-admin.php
+++ b/class.varnish-cache-admin.php
@@ -27,6 +27,7 @@ class ClpVarnishCacheAdmin {
     }
 
     public function admin_entire_cache_purge() {
+        if (($_GET['page'] ?? '') === 'clp-varnish-cache') return;
         echo '<div id="notice" class="notice notice-success fade is-dismissible"><p><strong>' . esc_html__('Varnish Cache has been purged.', 'clp-varnish-cache') . '</strong></p></div>';
     }
 

--- a/class.varnish-cache-auto-purge.php
+++ b/class.varnish-cache-auto-purge.php
@@ -3,19 +3,19 @@
 class ClpVarnishCacheAutoPurge {
 
     public function __construct() {
-        add_action('upgrader_process_complete', array($this, 'auto_purge'), 100, 2);
-        add_action('deactivated_plugin', array($this, 'auto_purge'), 100);
-        add_action('activated_plugin', array($this, 'auto_purge'), 100);
-        add_action('switch_theme', array($this, 'auto_purge'), 100);
+        add_action('upgrader_process_complete', [$this, 'auto_purge'], 100, 2);
+        add_action('deactivated_plugin', [$this, 'auto_purge'], 100);
+        add_action('activated_plugin', [$this, 'auto_purge'], 100);
+        add_action('switch_theme', [$this, 'auto_purge'], 100);
     }
 
     public function auto_purge($upgrader_or_plugin = null, $options = null) {
         if (current_action() === 'upgrader_process_complete') {
             if (empty($options['action']) || $options['action'] !== 'update') return;
-            if (empty($options['type']) || ! in_array( $options['type'], ['plugin', 'theme', 'core'], true)) return;
+            if (empty($options['type']) || !in_array($options['type'], ['plugin', 'theme', 'core'], true)) return;
         }
 
-        if (!class_exists( 'ClpVarnishCacheManager')) return;
+        if (!class_exists('ClpVarnishCacheManager')) return;
         $manager = new ClpVarnishCacheManager();
         $manager->purge_entire_cache();
     }

--- a/class.varnish-cache-auto-purge.php
+++ b/class.varnish-cache-auto-purge.php
@@ -17,13 +17,6 @@ class ClpVarnishCacheAutoPurge {
 
         if (!class_exists( 'ClpVarnishCacheManager')) return;
         $manager = new ClpVarnishCacheManager();
-
-        if (!$manager->is_enabled()) return;
-
-        $host = wp_parse_url(home_url(), PHP_URL_HOST);
-        if (!empty($host)) $manager->purge_host($host);
-
-        $prefix = $manager->get_cache_tag_prefix();
-        if (!empty($prefix)) $manager->purge_tag($prefix);
+        $manager->purge_entire_cache();
     }
 }

--- a/class.varnish-cache-manager.php
+++ b/class.varnish-cache-manager.php
@@ -5,161 +5,120 @@ class ClpVarnishCacheManager {
     private $cache_settings = [];
 
     public function is_enabled() {
-        $settings = $this->get_cache_settings();
-        $is_enabled = (true === isset($settings['enabled']) && true === $settings['enabled'] ? true : false);
-        return $is_enabled;
+        return !empty($this->get_cache_settings()['enabled']);
     }
 
     public function get_server() {
-        $settings = $this->get_cache_settings();
-        $server = (true === isset($settings['server']) ? $settings['server'] : '');
-        return $server;
+        return $this->get_cache_settings()['server'] ?? '';
     }
 
     public function get_cache_lifetime() {
-        $settings = $this->get_cache_settings();
-        $cache_lifetime = (true === isset($settings['cacheLifetime']) ? $settings['cacheLifetime'] : '');
-        return $cache_lifetime;
+        return $this->get_cache_settings()['cacheLifetime'] ?? '';
     }
 
     public function get_cache_tag_prefix() {
-        $settings = $this->get_cache_settings();
-        $cache_tag_prefix = (true === isset($settings['cacheTagPrefix']) ? $settings['cacheTagPrefix'] : '');
-        return $cache_tag_prefix;
+        return $this->get_cache_settings()['cacheTagPrefix'] ?? '';
     }
 
     public function get_excluded_params() {
-        $settings = $this->get_cache_settings();
-        $excluded_params = (true === isset($settings['excludedParams']) ? (array)$settings['excludedParams'] : []);
-        $excluded_params = implode(',', $excluded_params);
-        return $excluded_params;
+        $excluded_params = $this->get_cache_settings()['excludedParams'] ?? [];
+        return implode(',', (array)$excluded_params);
     }
 
     public function get_excludes() {
-        $settings = $this->get_cache_settings();
-        $excludes = (true === isset($settings['excludes']) ? (array)$settings['excludes'] : []);
-        $excludes = implode(PHP_EOL, $excludes);
-        return $excludes;
+        $excludes = $this->get_cache_settings()['excludes'] ?? [];
+        return implode(PHP_EOL, (array)$excludes);
     }
 
     public function get_cache_settings() {
-        if (true === empty($this->cache_settings)) {
-            $settings_file = sprintf('%s/.varnish-cache/settings.json', rtrim(getenv('HOME'), '/'));
-            if (file_exists($settings_file) && is_readable($settings_file)) {
-                $file_content = file_get_contents($settings_file);
-                if ($file_content !== false) {
-                    $cache_settings = json_decode($file_content, true);
-                    if (json_last_error() === JSON_ERROR_NONE && !empty($cache_settings)) {
-                        $this->cache_settings = $cache_settings;
-                    }
-                }
-            }
-        }
+        if (!empty($this->cache_settings)) return $this->cache_settings;
+
+        $settings_file = sprintf('%s/.varnish-cache/settings.json', rtrim(getenv('HOME'), '/'));
+        if (!file_exists($settings_file) || !is_readable($settings_file)) return $this->cache_settings;
+
+        $file_content = file_get_contents($settings_file);
+        if ($file_content === false) return $this->cache_settings;
+
+        $cache_settings = json_decode($file_content, true);
+        if (json_last_error() === JSON_ERROR_NONE && !empty($cache_settings)) $this->cache_settings = $cache_settings;
+
         return $this->cache_settings;
     }
 
     public function purge_entire_cache(): bool {
-        if ( ! $this->is_enabled() ) {
-            return false;
-        }
+        if (!$this->is_enabled()) return false;
 
-        $host = wp_parse_url( home_url(), PHP_URL_HOST );
-        if ( ! empty( $host ) ) {
-            $this->purge_host( $host );
-        }
+        $host = wp_parse_url(home_url(), PHP_URL_HOST);
+        if (!empty($host)) $this->purge_host($host);
 
         $prefix = $this->get_cache_tag_prefix();
-        if ( ! empty( $prefix ) ) {
-            $this->purge_tag( $prefix );
-        }
+        if (!empty($prefix)) $this->purge_tag($prefix);
 
         return true;
     }
 
     public function write_cache_settings(array $settings) {
         $settings_file = sprintf('%s/.varnish-cache/settings.json', rtrim(getenv('HOME'), '/'));
-        $settings = json_encode($settings, JSON_PRETTY_PRINT);
-        file_put_contents($settings_file, $settings);
+        file_put_contents($settings_file, json_encode($settings, JSON_PRETTY_PRINT));
     }
 
     public function reset_cache_settings() {
         $this->cache_settings = [];
     }
 
-    public function purge_host($host): void
-    {
-        $headers = [
-           'Host' => $host
-        ];
-        $this->purge($headers);
+    public function purge_host($host): void {
+        $this->purge(['Host' => $host]);
     }
 
-    public function purge_tag($tag): void
-    {
+    public function purge_tag($tag): void {
         $this->purge_tags([$tag]);
     }
 
-    public function purge_tags(array $tags): void
-    {
-        $headers = [
-            'X-Cache-Tags' => implode(',', $tags)
-        ];
-        $this->purge($headers);
+    public function purge_tags(array $tags): void {
+        $this->purge(['X-Cache-Tags' => implode(',', $tags)]);
     }
 
-    public function purge_url( $url): void
-    {
+    public function purge_url($url): void {
         $parsed_url = parse_url($url);
-        if (true === isset($parsed_url['host'])) {
-            $server = $this->get_server();
-            $host = $parsed_url['host'];
-            $request_url = $server;
-            if (true === isset($parsed_url['path'])) {
-                $path = $parsed_url['path'];
-                $request_url = sprintf('%s/%s', $request_url, ('/' == $path ? '' : ltrim($path, '/')));
-            }
-            $query_string = parse_url($url, PHP_URL_QUERY);
-            if (false === empty($query_string)) {
-                parse_str($query_string, $query_params);
-                if (false === empty($query_params)) {
-                    $query_string = http_build_query($query_params);
-                    $request_url = sprintf('%s?%s', $request_url, $query_string);
-                }
-            }
-            $headers = [
-                'Host' => $host
-            ];
-            $this->purge($headers, $request_url);
-        } else {
-            throw new \Exception(sprintf('Not a valid url: %s', $url));
+        if (!isset($parsed_url['host'])) throw new \Exception(sprintf('Not a valid url: %s', $url));
+
+        $server = $this->get_server();
+        $host = $parsed_url['host'];
+        $request_url = $server;
+
+        if (isset($parsed_url['path'])) {
+            $path = $parsed_url['path'];
+            $request_url = sprintf('%s/%s', $request_url, ($path === '/' ? '' : ltrim($path, '/')));
         }
+
+        $query_string = parse_url($url, PHP_URL_QUERY);
+        if (!empty($query_string)) {
+            parse_str($query_string, $query_params);
+            if (!empty($query_params)) {
+                $request_url = sprintf('%s?%s', $request_url, http_build_query($query_params));
+            }
+        }
+
+        $this->purge(['Host' => $host], $request_url);
     }
 
-    private function purge(array $headers, $request_url = null): void
-    {
+    private function purge(array $headers, $request_url = null): void {
         try {
-            if (true === is_null($request_url)) {
-                $request_url = $this->get_server();
-            }
-            $request_url = sprintf('http://%s', $request_url);
+            if ($request_url === null) $request_url = $this->get_server();
+
             $response = wp_remote_request(
-                $request_url,
+                sprintf('http://%s', $request_url),
                 [
                     'sslverify' => false,
                     'method'    => 'PURGE',
                     'headers'   => $headers,
                 ]
             );
-            $http_status_code = 0;
-            if (true === isset($response['response']['code'])) {
-                $http_status_code = $response['response']['code'];
-            }
-            if (200 != $http_status_code) {
-                throw new \Exception(sprintf('HTTP Status Code: %s', $http_status_code));
-            }
+
+            $http_status_code = $response['response']['code'] ?? 0;
+            if ($http_status_code != 200) throw new \Exception(sprintf('HTTP Status Code: %s', $http_status_code));
         } catch (\Exception $e) {
-            $error_message = $e->getMessage();
-            echo esc_html(sprintf('Varnish Cache Purge Failed, Error Message: %s', $error_message));
+            echo esc_html(sprintf('Varnish Cache Purge Failed, Error Message: %s', $e->getMessage()));
             exit();
         }
     }

--- a/class.varnish-cache-manager.php
+++ b/class.varnish-cache-manager.php
@@ -45,14 +45,35 @@ class ClpVarnishCacheManager {
     public function get_cache_settings() {
         if (true === empty($this->cache_settings)) {
             $settings_file = sprintf('%s/.varnish-cache/settings.json', rtrim(getenv('HOME'), '/'));
-            if (true === file_exists($settings_file)) {
-                $cache_settings = @json_decode(file_get_contents($settings_file), true);
-                if (false === empty($cache_settings)) {
-                    $this->cache_settings = $cache_settings;
+            if (file_exists($settings_file) && is_readable($settings_file)) {
+                $file_content = file_get_contents($settings_file);
+                if ($file_content !== false) {
+                    $cache_settings = json_decode($file_content, true);
+                    if (json_last_error() === JSON_ERROR_NONE && !empty($cache_settings)) {
+                        $this->cache_settings = $cache_settings;
+                    }
                 }
             }
         }
         return $this->cache_settings;
+    }
+
+    public function purge_entire_cache(): bool {
+        if ( ! $this->is_enabled() ) {
+            return false;
+        }
+
+        $host = wp_parse_url( home_url(), PHP_URL_HOST );
+        if ( ! empty( $host ) ) {
+            $this->purge_host( $host );
+        }
+
+        $prefix = $this->get_cache_tag_prefix();
+        if ( ! empty( $prefix ) ) {
+            $this->purge_tag( $prefix );
+        }
+
+        return true;
     }
 
     public function write_cache_settings(array $settings) {

--- a/clp-varnish-cache.php
+++ b/clp-varnish-cache.php
@@ -13,19 +13,19 @@
  * GitHub Branch: master
  */
 
-if (false ===  function_exists('add_action')) {
-    echo 'Hi there!  I\'m just a plugin, not much I can do when called directly.';
+if (!function_exists('add_action')) {
+    echo 'Hi there! I\'m just a plugin, not much I can do when called directly.';
     exit;
 }
 
 define('CLP_VARNISH_VERSION', '1.1.0');
-$is_admin = is_admin();
 
-if (true === $is_admin) {
-    define('CLP_VARNISH_PLUGIN_DIR', plugin_dir_path( __FILE__));
-    require_once CLP_VARNISH_PLUGIN_DIR . 'class.varnish-cache-manager.php';
-    require_once CLP_VARNISH_PLUGIN_DIR . 'class.varnish-cache-admin.php';
-    require_once CLP_VARNISH_PLUGIN_DIR . 'class.varnish-cache-auto-purge.php';
-    $clp_varnish_cache_auto_purge = new ClpVarnishCacheAutoPurge();
-    $clp_varnish_cache_admin = new ClpVarnishCacheAdmin();
-}
+if (!is_admin()) return;
+
+define('CLP_VARNISH_PLUGIN_DIR', plugin_dir_path(__FILE__));
+require_once CLP_VARNISH_PLUGIN_DIR . 'class.varnish-cache-manager.php';
+require_once CLP_VARNISH_PLUGIN_DIR . 'class.varnish-cache-auto-purge.php';
+require_once CLP_VARNISH_PLUGIN_DIR . 'class.varnish-cache-admin.php';
+
+$clp_varnish_cache_auto_purge = new ClpVarnishCacheAutoPurge();
+$clp_varnish_cache_admin = new ClpVarnishCacheAdmin();

--- a/clp-varnish-cache.php
+++ b/clp-varnish-cache.php
@@ -2,10 +2,10 @@
 /*
  * Plugin Name: CLP Varnish Cache
  * Description: Varnish Cache Plugin by cloudpanel.io
- * Version: 1.1.0
+ * Version: 1.1.2
  * Text Domain: clp-varnish-cache
  * Domain Path: /languages
- * Requires at least: 6.0
+ * Requires WP at least: 6.0
  * Requires PHP: 7.1
  * Author: cloudpanel.io
  * Author URI: https://www.cloudpanel.io
@@ -18,7 +18,7 @@ if (!function_exists('add_action')) {
     exit;
 }
 
-define('CLP_VARNISH_VERSION', '1.1.0');
+define('CLP_VARNISH_VERSION', '1.1.2');
 
 if (!is_admin()) return;
 

--- a/pages/clp-varnish-cache.php
+++ b/pages/clp-varnish-cache.php
@@ -24,7 +24,7 @@ if (isset($_POST['action']) && $_POST['action'] === 'save-settings') {
     $excluded_params = array_map('trim', array_filter(explode(',', getPostValue('excluded-params'))));
     $excludes = isset($_POST['excludes']) ? sanitize_textarea_field($_POST['excludes']) : '';
     $excludes = array_map('trim', array_filter(explode(PHP_EOL, $excludes)));
-    
+
     if (!empty($server) && !empty($cache_lifetime) && !empty($cache_tag_prefix)) {
         $clp_cache_manager->write_cache_settings([
             'enabled'        => $enabled,
@@ -35,7 +35,7 @@ if (isset($_POST['action']) && $_POST['action'] === 'save-settings') {
             'excludedParams' => $excluded_params,
         ]);
         $clp_cache_manager->reset_cache_settings();
-        
+
         if (!$enabled) {
             if (!empty($old_cache_tag_prefix)) $clp_cache_manager->purge_tag($old_cache_tag_prefix);
             if (!empty($host)) $clp_cache_manager->purge_host($host);
@@ -71,118 +71,126 @@ $cache_lifetime = $clp_cache_manager->get_cache_lifetime();
 $cache_tag_prefix = $clp_cache_manager->get_cache_tag_prefix();
 $excluded_params = $clp_cache_manager->get_excluded_params();
 $excludes = $clp_cache_manager->get_excludes();
+$excludes_text = is_array($excludes) ? implode(PHP_EOL, $excludes) : $excludes;
 
 ?>
-<h1 id="clp-varnish-cache"><?php esc_html_e('CLP Varnish Cache', 'clp-varnish-cache'); ?></h1>
-
 <div class="clp-varnish-cache-container">
   <?php if (!empty($clp_cache_settings)): ?>
+
     <?php if ($successNotice !== null): ?>
       <div id="notice" class="notice notice-success fade is-dismissible">
-        <p><strong><?php echo esc_html__($successNotice, 'clp-varnish-cache'); ?></strong></p>
+        <p><strong><?php echo esc_html($successNotice); ?></strong></p>
       </div>
     <?php endif; ?>
     <?php if ($errorNotice !== null): ?>
       <div id="notice" class="notice notice-error fade is-dismissible">
-        <p><strong><?php echo esc_html__($errorNotice, 'clp-varnish-cache'); ?></strong></p>
+        <p><strong><?php echo esc_html($errorNotice); ?></strong></p>
       </div>
     <?php endif; ?>
-    <div class="clp-varnish-cache-block-container">
-      <form action="<?php echo esc_url($form_action_url); ?>" method="post">
-        <div class="clp-varnish-cache-block">
-          <div class="clp-varnish-cache-block-header">
-            <h3><?php esc_html_e('Settings', 'clp-varnish-cache'); ?></h3>
-          </div>
-          <div class="clp-varnish-cache-block-content clp-varnish-cache-block-settings">
-            <table class="form-table">
-              <tbody>
-                <tr>
-                  <td class="field-name"><?php esc_html_e('Enable Varnish Cache', 'clp-varnish-cache'); ?>:</td>
-                  <td><input type="checkbox" name="enabled" <?php echo ($is_enabled ? 'checked' : ''); ?> value="1" /></td>
-                </tr>
-                <tr>
-                  <td class="field-name"><?php esc_html_e('Varnish Server', 'clp-varnish-cache'); ?>:</td>
-                  <td><input type="text" name="server" required="required" value="<?php echo esc_html($server); ?>" /></td>
-                </tr>
-                <tr>
-                  <td class="field-name"><?php esc_html_e('Cache Lifetime', 'clp-varnish-cache'); ?>:</td>
-                  <td>
-                    <input type="text" name="cache-lifetime" required="required" value="<?php echo esc_html($cache_lifetime); ?>" />
-                    <p class="description"><?php esc_html_e('Cache Lifetime in seconds before being refreshed.', 'clp-varnish-cache'); ?></p>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="field-name"><?php esc_html_e('Cache Tag Prefix', 'clp-varnish-cache'); ?>:</td>
-                  <td><input type="text" name="cache-tag-prefix" required="required" value="<?php echo esc_html($cache_tag_prefix); ?>" /></td>
-                </tr>
-                <tr>
-                  <td class="field-name"><?php esc_html_e('Excluded Params', 'clp-varnish-cache'); ?>:</td>
-                  <td>
-                    <input type="text" name="excluded-params" value="<?php echo esc_html($excluded_params); ?>" />
-                    <p class="description"><?php esc_html_e('List of GET parameters, separated by a comma, to disable caching.', 'clp-varnish-cache'); ?></p>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="field-name"><?php esc_html_e('Excludes', 'clp-varnish-cache'); ?>:</td>
-                  <td>
-                    <textarea name="excludes" rows="6"><?php echo esc_textarea($excludes); ?></textarea>
-                    <p class="description"><?php esc_html_e('Urls and files that Varnish Cache shouldn\'t cache.', 'clp-varnish-cache'); ?></p>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <?php wp_nonce_field('clp_varnish_save_settings', 'clp_varnish_nonce'); ?>
-            <input type="hidden" name="action" value="save-settings" />
-            <input type="submit" class="button action" value="<?php esc_html_e('Save', 'clp-varnish-cache'); ?>" />
-          </div>
-        </div>
-      </form>
-      <form action="<?php echo esc_url($form_action_url); ?>" method="post">
-        <div class="clp-varnish-cache-block">
-          <div class="clp-varnish-cache-block-header">
-            <h3><?php esc_html_e('Purge Cache', 'clp-varnish-cache'); ?></h3>
-            <a class="button button-primary" href="<?php echo wp_nonce_url($form_action_url . '&action=purge-entire-cache', 'purge-entire-cache'); ?>">Purge Entire Cache</a>
-          </div>
-          <div class="clp-varnish-cache-block-content clp-varnish-cache-block-purge-cache">
-            <table class="form-table">
-              <tbody>
-                <tr>
-                  <td>
-                    <input type="text" name="purge-value" required="required" class="purge-value" placeholder="https://www.domain.com/site.html">
-                    <p class="description"><?php esc_html_e('You can purge single urls or tags separated by comma.', 'clp-varnish-cache'); ?></p>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-            <?php wp_nonce_field('clp_varnish_purge_cache', 'clp_varnish_nonce'); ?>
-            <input type="hidden" name="action" value="purge-cache" />
-            <input type="submit" class="button action" value="<?php esc_html_e('Purge Cache', 'clp-varnish-cache'); ?>" />
-          </div>
-        </div>
-      </form>
+
+    <!-- Settings Card -->
+    <form action="<?php echo esc_url($form_action_url); ?>" method="post">
       <div class="clp-varnish-cache-block">
         <div class="clp-varnish-cache-block-header">
-          <h3><?php esc_html_e('Support', 'clp-varnish-cache'); ?></h3>
+          <h3>
+            <label class="clp-toggle" title="<?php esc_attr_e('Enable Varnish Cache', 'clp-varnish-cache'); ?>">
+              <input type="checkbox" name="enabled" value="1" <?php checked($is_enabled); ?>>
+              <span class="clp-toggle-slider"></span>
+            </label>
+            <?php esc_html_e('Varnish Cache', 'clp-varnish-cache'); ?>
+          </h3>
         </div>
-         <div class="clp-varnish-cache-block-content">
-           <table class="form-table">
-             <tbody>
-               <tr>
-                 <td class="field-name"><?php esc_html_e('Documentation', 'clp-varnish-cache'); ?>:</td>
-                 <td><a target="_blank" href="https://www.cloudpanel.io/docs/v2/frontend-area/varnish-cache/wordpress/plugin/">https://www.cloudpanel.io/docs/v2/frontend-area/varnish-cache/wordpress/plugin/</a></td>
-               </tr>
-               <tr>
-                 <td class="field-name"><?php esc_html_e('Discord', 'clp-varnish-cache'); ?>:</td>
-                 <td><a target="_blank" href="https://discord.cloudpanel.io/">https://discord.cloudpanel.io/</a></td>
-               </tr>
-             </tbody>
-           </table>
-         </div>
+        <div class="clp-varnish-cache-block-content">
+          <div class="clp-form-grid">
+            <div class="clp-form-group">
+              <label for="clp-server">
+                <?php esc_html_e('Varnish Server', 'clp-varnish-cache'); ?>
+                <span class="clp-required">*</span>
+              </label>
+              <input type="text" id="clp-server" name="server" required value="<?php echo esc_attr($server); ?>" placeholder="127.0.0.1:6081">
+            </div>
+            <div class="clp-form-group">
+              <label for="clp-cache-lifetime">
+                <?php esc_html_e('Cache Lifetime', 'clp-varnish-cache'); ?>
+                <span class="clp-required">*</span>
+              </label>
+              <input type="text" id="clp-cache-lifetime" name="cache-lifetime" required value="<?php echo esc_attr($cache_lifetime); ?>">
+              <p class="description"><?php esc_html_e('Cache Lifetime in seconds before being refreshed.', 'clp-varnish-cache'); ?></p>
+            </div>
+            <div class="clp-form-group">
+              <label for="clp-cache-tag-prefix">
+                <?php esc_html_e('Cache Tag Prefix', 'clp-varnish-cache'); ?>
+                <span class="clp-required">*</span>
+              </label>
+              <input type="text" id="clp-cache-tag-prefix" name="cache-tag-prefix" required value="<?php echo esc_attr($cache_tag_prefix); ?>">
+            </div>
+            <div class="clp-form-group">
+              <label for="clp-excluded-params"><?php esc_html_e('Excluded Params', 'clp-varnish-cache'); ?></label>
+              <input type="text" id="clp-excluded-params" name="excluded-params" value="<?php echo esc_attr(is_array($excluded_params) ? implode(',', $excluded_params) : $excluded_params); ?>">
+              <p class="description"><?php esc_html_e('List of GET parameters, separated by a comma, to disable caching.', 'clp-varnish-cache'); ?></p>
+            </div>
+            <div class="clp-form-group clp-full-col">
+              <label for="clp-excludes"><?php esc_html_e('Excludes', 'clp-varnish-cache'); ?></label>
+              <textarea id="clp-excludes" name="excludes" rows="6"><?php echo esc_textarea($excludes_text); ?></textarea>
+              <p class="description"><?php esc_html_e('Urls and files that Varnish Cache shouldn\'t cache.', 'clp-varnish-cache'); ?></p>
+            </div>
+          </div>
+        </div>
+        <div class="clp-varnish-cache-block-footer">
+          <?php wp_nonce_field('clp_varnish_save_settings', 'clp_varnish_nonce'); ?>
+          <input type="hidden" name="action" value="save-settings">
+          <input type="submit" class="button clp-btn-primary" value="<?php esc_attr_e('Save', 'clp-varnish-cache'); ?>">
+        </div>
+      </div>
+    </form>
+
+    <!-- Purge Cache Card -->
+    <form action="<?php echo esc_url($form_action_url); ?>" method="post">
+      <div class="clp-varnish-cache-block">
+        <div class="clp-varnish-cache-block-header">
+          <h3><?php esc_html_e('Purge Cache', 'clp-varnish-cache'); ?></h3>
+          <a class="button clp-btn-secondary" href="<?php echo esc_url(wp_nonce_url($form_action_url . '&action=purge-entire-cache', 'purge-entire-cache')); ?>">
+            <?php esc_html_e('Purge Entire Cache', 'clp-varnish-cache'); ?>
+          </a>
+        </div>
+        <div class="clp-varnish-cache-block-content">
+          <div class="clp-form-group">
+            <input type="text" name="purge-value" required placeholder="https://www.domain.com/site.html">
+            <p class="description"><?php esc_html_e('You can purge single urls or tags separated by comma.', 'clp-varnish-cache'); ?></p>
+          </div>
+        </div>
+        <div class="clp-varnish-cache-block-footer">
+          <?php wp_nonce_field('clp_varnish_purge_cache', 'clp_varnish_nonce'); ?>
+          <input type="hidden" name="action" value="purge-cache">
+          <input type="submit" class="button clp-btn-primary" value="<?php esc_attr_e('Purge Cache', 'clp-varnish-cache'); ?>">
+        </div>
+      </div>
+    </form>
+
+    <!-- Support Card -->
+    <div class="clp-varnish-cache-block">
+      <div class="clp-varnish-cache-block-header">
+        <h3><?php esc_html_e('Support', 'clp-varnish-cache'); ?></h3>
+      </div>
+      <div class="clp-varnish-cache-block-content">
+        <table class="clp-support-table">
+          <tbody>
+            <tr>
+              <td><?php esc_html_e('Documentation', 'clp-varnish-cache'); ?>:</td>
+              <td><a target="_blank" href="https://www.cloudpanel.io/docs/v2/frontend-area/varnish-cache/wordpress/plugin/">https://www.cloudpanel.io/docs/v2/frontend-area/varnish-cache/wordpress/plugin/</a></td>
+            </tr>
+            <tr>
+              <td><?php esc_html_e('Discord', 'clp-varnish-cache'); ?>:</td>
+              <td><a target="_blank" href="https://discord.cloudpanel.io/">https://discord.cloudpanel.io/</a></td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
+
   <?php else: ?>
     <div id="notice" class="notice notice-error fade is-dismissible">
-      <p><strong><?php echo esc_html__('Settings File Not Found!', 'clp-varnish-cache'); ?></strong></p>
+      <p><strong><?php esc_html_e('Settings File Not Found!', 'clp-varnish-cache'); ?></strong></p>
     </div>
-  <?php endif ?>
+  <?php endif; ?>
 </div>

--- a/pages/clp-varnish-cache.php
+++ b/pages/clp-varnish-cache.php
@@ -14,6 +14,10 @@ function getPostValue($key) {
 $clp_cache_manager = $clp_varnish_cache_admin->get_clp_cache_manager();
 
 if (true === isset($_POST['action']) && 'save-settings' == sanitize_text_field($_POST['action'])) {
+    if ( ! isset( $_POST['clp_varnish_nonce'] ) || ! wp_verify_nonce( sanitize_text_field($_POST['clp_varnish_nonce']), 'clp_varnish_save_settings' ) ) {
+        wp_die( 'Security check failed.' );
+    }
+    
     $old_cache_tag_prefix = $clp_cache_manager->get_cache_tag_prefix();
     $enabled = (1 == getPostValue('enabled')  ? true : false);
     $server = getPostValue('server');
@@ -46,6 +50,10 @@ if (true === isset($_POST['action']) && 'save-settings' == sanitize_text_field($
 }
 
 if (true === isset($_POST['action']) && 'purge-cache' == sanitize_text_field($_POST['action'])) {
+    if ( ! isset( $_POST['clp_varnish_nonce'] ) || ! wp_verify_nonce( sanitize_text_field($_POST['clp_varnish_nonce']), 'clp_varnish_purge_cache' ) ) {
+        wp_die( 'Security check failed.' );
+    }
+    
     $purge_values = array_map('trim', array_filter(explode(',', getPostValue('purge-value'))));
     if (false === empty($purge_values)) {
         foreach ($purge_values as $purge_value) {
@@ -63,13 +71,11 @@ if (true === isset($_POST['action']) && 'purge-cache' == sanitize_text_field($_P
 }
 
 if (true === isset($_GET['action']) && 'purge-entire-cache' == sanitize_text_field($_GET['action'])) {
-    if (false === empty($host)) {
-        $clp_cache_manager->purge_host($host);
+    if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( $_GET['_wpnonce'] ), 'purge-entire-cache' ) ) {
+        wp_die( 'Security check failed.' );
     }
-    $cache_tag_prefix = $clp_cache_manager->get_cache_tag_prefix();
-    if (false === empty($cache_tag_prefix)) {
-        $clp_cache_manager->purge_tag($cache_tag_prefix);
-    }
+    
+    $clp_cache_manager->purge_entire_cache();
     $successNotice = 'Varnish Cache has been purged.';
 }
 
@@ -158,6 +164,7 @@ $excludes = $clp_cache_manager->get_excludes();
                 </tr>
               </tbody>
             </table>
+            <?php wp_nonce_field( 'clp_varnish_save_settings', 'clp_varnish_nonce' ); ?>
             <input type="hidden" name="action" value="save-settings" />
             <input type="submit" class="button action" value="<?php esc_html_e( 'Save', 'clp-varnish-cache' ); ?>" />
           </div>
@@ -167,7 +174,7 @@ $excludes = $clp_cache_manager->get_excludes();
         <div class="clp-varnish-cache-block">
           <div class="clp-varnish-cache-block-header">
             <h3><?php esc_html_e( 'Purge Cache', 'clp-varnish-cache' ); ?></h3>
-            <a class="button button-primary" href="<?php echo (true === $is_network ? network_admin_url('settings.php?page=clp-varnish-cache&action=purge-entire-cache') : admin_url('options-general.php?page=clp-varnish-cache&action=purge-entire-cache')) ?>">Purge Entire Cache</a>
+            <a class="button button-primary" href="<?php echo wp_nonce_url((true === $is_network ? network_admin_url('settings.php?page=clp-varnish-cache&action=purge-entire-cache') : admin_url('options-general.php?page=clp-varnish-cache&action=purge-entire-cache')), 'purge-entire-cache') ?>">Purge Entire Cache</a>
           </div>
           <div class="clp-varnish-cache-block-content clp-varnish-cache-block-purge-cache">
             <table class="form-table">
@@ -180,6 +187,7 @@ $excludes = $clp_cache_manager->get_excludes();
                 </tr>
               </tbody>
             </table>
+            <?php wp_nonce_field( 'clp_varnish_purge_cache', 'clp_varnish_nonce' ); ?>
             <input type="hidden" name="action" value="purge-cache" />
             <input type="submit" class="button action" value="<?php esc_html_e( 'Purge Cache', 'clp-varnish-cache' ); ?>" />
           </div>

--- a/pages/clp-varnish-cache.php
+++ b/pages/clp-varnish-cache.php
@@ -4,77 +4,62 @@ global $clp_varnish_cache_admin;
 $is_network = is_multisite() && is_network_admin();
 $successNotice = null;
 $errorNotice = null;
-$host = (true === isset($_SERVER['HTTP_HOST']) && false === empty(sanitize_text_field($_SERVER['HTTP_HOST'])) ? sanitize_text_field($_SERVER['HTTP_HOST']) : '');
+$host = !empty($_SERVER['HTTP_HOST']) ? sanitize_text_field($_SERVER['HTTP_HOST']) : '';
 
 function getPostValue($key) {
-    $postValue = (true === isset($_POST[$key]) && false === empty(sanitize_text_field($_POST[$key])) ? sanitize_text_field($_POST[$key]) : '');
-    return $postValue;
+    return !empty($_POST[$key]) ? sanitize_text_field($_POST[$key]) : '';
 }
 
 $clp_cache_manager = $clp_varnish_cache_admin->get_clp_cache_manager();
+$form_action_url = $is_network ? network_admin_url('settings.php?page=clp-varnish-cache') : admin_url('options-general.php?page=clp-varnish-cache');
 
-if (true === isset($_POST['action']) && 'save-settings' == sanitize_text_field($_POST['action'])) {
-    if ( ! isset( $_POST['clp_varnish_nonce'] ) || ! wp_verify_nonce( sanitize_text_field($_POST['clp_varnish_nonce']), 'clp_varnish_save_settings' ) ) {
-        wp_die( 'Security check failed.' );
-    }
-    
+if (isset($_POST['action']) && $_POST['action'] === 'save-settings') {
+    if (!isset($_POST['clp_varnish_nonce']) || !wp_verify_nonce(sanitize_text_field($_POST['clp_varnish_nonce']), 'clp_varnish_save_settings')) wp_die('Security check failed.');
+
     $old_cache_tag_prefix = $clp_cache_manager->get_cache_tag_prefix();
-    $enabled = (1 == getPostValue('enabled')  ? true : false);
+    $enabled = getPostValue('enabled') == 1;
     $server = getPostValue('server');
     $cache_lifetime = getPostValue('cache-lifetime');
     $cache_tag_prefix = getPostValue('cache-tag-prefix');
     $excluded_params = array_map('trim', array_filter(explode(',', getPostValue('excluded-params'))));
-    $excludes = (true === isset($_POST['excludes']) ? sanitize_textarea_field($_POST['excludes']) : '');
+    $excludes = isset($_POST['excludes']) ? sanitize_textarea_field($_POST['excludes']) : '';
     $excludes = array_map('trim', array_filter(explode(PHP_EOL, $excludes)));
-    if (false === empty($server) && false === empty($cache_lifetime) && false === empty($cache_tag_prefix)) {
-        $cache_settings = [
+    
+    if (!empty($server) && !empty($cache_lifetime) && !empty($cache_tag_prefix)) {
+        $clp_cache_manager->write_cache_settings([
             'enabled'        => $enabled,
             'server'         => $server,
             'cacheTagPrefix' => $cache_tag_prefix,
             'cacheLifetime'  => $cache_lifetime,
             'excludes'       => $excludes,
             'excludedParams' => $excluded_params,
-        ];
-        $clp_cache_manager->write_cache_settings($cache_settings);
+        ]);
         $clp_cache_manager->reset_cache_settings();
-        if (false === $enabled) {
-            if (false === empty($old_cache_tag_prefix)) {
-                $clp_cache_manager->purge_tag($old_cache_tag_prefix);
-            }
-            if (false === empty($host)) {
-                $clp_cache_manager->purge_host($host);
-            }
+        
+        if (!$enabled) {
+            if (!empty($old_cache_tag_prefix)) $clp_cache_manager->purge_tag($old_cache_tag_prefix);
+            if (!empty($host)) $clp_cache_manager->purge_host($host);
         }
         $successNotice = 'Settings have been saved.';
     }
 }
 
-if (true === isset($_POST['action']) && 'purge-cache' == sanitize_text_field($_POST['action'])) {
-    if ( ! isset( $_POST['clp_varnish_nonce'] ) || ! wp_verify_nonce( sanitize_text_field($_POST['clp_varnish_nonce']), 'clp_varnish_purge_cache' ) ) {
-        wp_die( 'Security check failed.' );
-    }
-    
+if (isset($_POST['action']) && $_POST['action'] === 'purge-cache') {
+    if (!isset($_POST['clp_varnish_nonce']) || !wp_verify_nonce(sanitize_text_field($_POST['clp_varnish_nonce']), 'clp_varnish_purge_cache')) wp_die('Security check failed.');
+
     $purge_values = array_map('trim', array_filter(explode(',', getPostValue('purge-value'))));
-    if (false === empty($purge_values)) {
-        foreach ($purge_values as $purge_value) {
-            $purge_value = trim($purge_value);
-            if (false === empty($purge_value)) {
-                if (true === str_starts_with($purge_value, 'http')) {
-                    $clp_cache_manager->purge_url($purge_value);
-                } else {
-                    $clp_cache_manager->purge_tag($purge_value);
-                }
-            }
-        }
-        $successNotice = 'Varnish Cache has been purged.';
+    foreach ($purge_values as $purge_value) {
+        if (empty($purge_value)) continue;
+
+        if (strpos($purge_value, 'http') === 0) $clp_cache_manager->purge_url($purge_value);
+        else $clp_cache_manager->purge_tag($purge_value);
     }
+    if (!empty($purge_values)) $successNotice = 'Varnish Cache has been purged.';
 }
 
-if (true === isset($_GET['action']) && 'purge-entire-cache' == sanitize_text_field($_GET['action'])) {
-    if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( $_GET['_wpnonce'] ), 'purge-entire-cache' ) ) {
-        wp_die( 'Security check failed.' );
-    }
-    
+if (isset($_GET['action']) && $_GET['action'] === 'purge-entire-cache') {
+    if (!isset($_GET['_wpnonce']) || !wp_verify_nonce(sanitize_text_field($_GET['_wpnonce']), 'purge-entire-cache')) wp_die('Security check failed.');
+
     $clp_cache_manager->purge_entire_cache();
     $successNotice = 'Varnish Cache has been purged.';
 }
@@ -88,93 +73,75 @@ $excluded_params = $clp_cache_manager->get_excluded_params();
 $excludes = $clp_cache_manager->get_excludes();
 
 ?>
-<h1 id="clp-varnish-cache"><?php esc_html_e( 'CLP Varnish Cache', 'clp-varnish-cache' ); ?></h1>
+<h1 id="clp-varnish-cache"><?php esc_html_e('CLP Varnish Cache', 'clp-varnish-cache'); ?></h1>
 
 <div class="clp-varnish-cache-container">
-  <?php if (false === empty($clp_cache_settings)): ?>
-    <?php if (false === is_null($successNotice)): ?>
+  <?php if (!empty($clp_cache_settings)): ?>
+    <?php if ($successNotice !== null): ?>
       <div id="notice" class="notice notice-success fade is-dismissible">
         <p><strong><?php echo esc_html__($successNotice, 'clp-varnish-cache'); ?></strong></p>
       </div>
     <?php endif; ?>
-    <?php if (false === is_null($errorNotice)): ?>
+    <?php if ($errorNotice !== null): ?>
       <div id="notice" class="notice notice-error fade is-dismissible">
         <p><strong><?php echo esc_html__($errorNotice, 'clp-varnish-cache'); ?></strong></p>
       </div>
     <?php endif; ?>
     <div class="clp-varnish-cache-block-container">
-      <form action="<?php echo (true === $is_network ? network_admin_url('settings.php?page=clp-varnish-cache') : admin_url('options-general.php?page=clp-varnish-cache')) ?>" method="post">
+      <form action="<?php echo esc_url($form_action_url); ?>" method="post">
         <div class="clp-varnish-cache-block">
           <div class="clp-varnish-cache-block-header">
-            <h3><?php esc_html_e( 'Settings', 'clp-varnish-cache' ); ?></h3>
+            <h3><?php esc_html_e('Settings', 'clp-varnish-cache'); ?></h3>
           </div>
           <div class="clp-varnish-cache-block-content clp-varnish-cache-block-settings">
             <table class="form-table">
               <tbody>
                 <tr>
-                  <td class="field-name">
-                    <?php esc_html_e( 'Enable Varnish Cache', 'clp-varnish-cache' ); ?>:
-                  </td>
-                  <td>
-                    <input type="checkbox" name="enabled" <?php echo (true === $is_enabled ? 'checked' : ''); ?> value="1" />
-                  </td>
+                  <td class="field-name"><?php esc_html_e('Enable Varnish Cache', 'clp-varnish-cache'); ?>:</td>
+                  <td><input type="checkbox" name="enabled" <?php echo ($is_enabled ? 'checked' : ''); ?> value="1" /></td>
                 </tr>
                 <tr>
-                  <td class="field-name">
-                    <?php esc_html_e( 'Varnish Server', 'clp-varnish-cache' ); ?>:
-                  </td>
-                  <td>
-                    <input type="text" name="server" required="required" value="<?php echo esc_html($server); ?>" />
-                  </td>
+                  <td class="field-name"><?php esc_html_e('Varnish Server', 'clp-varnish-cache'); ?>:</td>
+                  <td><input type="text" name="server" required="required" value="<?php echo esc_html($server); ?>" /></td>
                 </tr>
                 <tr>
-                  <td class="field-name">
-                    <?php esc_html_e( 'Cache Lifetime', 'clp-varnish-cache' ); ?>:
-                  </td>
+                  <td class="field-name"><?php esc_html_e('Cache Lifetime', 'clp-varnish-cache'); ?>:</td>
                   <td>
                     <input type="text" name="cache-lifetime" required="required" value="<?php echo esc_html($cache_lifetime); ?>" />
-                    <p class="description"><?php esc_html_e( 'Cache Lifetime in seconds before being refreshed.', 'clp-varnish-cache' ); ?></p>
+                    <p class="description"><?php esc_html_e('Cache Lifetime in seconds before being refreshed.', 'clp-varnish-cache'); ?></p>
                   </td>
                 </tr>
                 <tr>
-                  <td class="field-name">
-                    <?php esc_html_e( 'Cache Tag Prefix', 'clp-varnish-cache' ); ?>:
-                  </td>
-                  <td>
-                    <input type="text" name="cache-tag-prefix" required="required" value="<?php echo esc_html($cache_tag_prefix); ?>" />
-                  </td>
+                  <td class="field-name"><?php esc_html_e('Cache Tag Prefix', 'clp-varnish-cache'); ?>:</td>
+                  <td><input type="text" name="cache-tag-prefix" required="required" value="<?php echo esc_html($cache_tag_prefix); ?>" /></td>
                 </tr>
                 <tr>
-                  <td class="field-name">
-                    <?php esc_html_e( 'Excluded Params', 'clp-varnish-cache' ); ?>:
-                  </td>
+                  <td class="field-name"><?php esc_html_e('Excluded Params', 'clp-varnish-cache'); ?>:</td>
                   <td>
                     <input type="text" name="excluded-params" value="<?php echo esc_html($excluded_params); ?>" />
-                    <p class="description"><?php esc_html_e( 'List of GET parameters, separated by a comma, to disable caching.', 'clp-varnish-cache' ); ?></p>
+                    <p class="description"><?php esc_html_e('List of GET parameters, separated by a comma, to disable caching.', 'clp-varnish-cache'); ?></p>
                   </td>
                 </tr>
                 <tr>
-                  <td class="field-name">
-                    <?php esc_html_e( 'Excludes', 'clp-varnish-cache' ); ?>:
-                  </td>
+                  <td class="field-name"><?php esc_html_e('Excludes', 'clp-varnish-cache'); ?>:</td>
                   <td>
                     <textarea name="excludes" rows="6"><?php echo esc_textarea($excludes); ?></textarea>
-                    <p class="description"><?php esc_html_e( 'Urls and files that Varnish Cache shouldn\'t cache.', 'clp-varnish-cache' ); ?></p>
+                    <p class="description"><?php esc_html_e('Urls and files that Varnish Cache shouldn\'t cache.', 'clp-varnish-cache'); ?></p>
                   </td>
                 </tr>
               </tbody>
             </table>
-            <?php wp_nonce_field( 'clp_varnish_save_settings', 'clp_varnish_nonce' ); ?>
+            <?php wp_nonce_field('clp_varnish_save_settings', 'clp_varnish_nonce'); ?>
             <input type="hidden" name="action" value="save-settings" />
-            <input type="submit" class="button action" value="<?php esc_html_e( 'Save', 'clp-varnish-cache' ); ?>" />
+            <input type="submit" class="button action" value="<?php esc_html_e('Save', 'clp-varnish-cache'); ?>" />
           </div>
         </div>
       </form>
-      <form action="<?php echo (true === $is_network ? network_admin_url('settings.php?page=clp-varnish-cache') : admin_url('options-general.php?page=clp-varnish-cache')) ?>" method="post">
+      <form action="<?php echo esc_url($form_action_url); ?>" method="post">
         <div class="clp-varnish-cache-block">
           <div class="clp-varnish-cache-block-header">
-            <h3><?php esc_html_e( 'Purge Cache', 'clp-varnish-cache' ); ?></h3>
-            <a class="button button-primary" href="<?php echo wp_nonce_url((true === $is_network ? network_admin_url('settings.php?page=clp-varnish-cache&action=purge-entire-cache') : admin_url('options-general.php?page=clp-varnish-cache&action=purge-entire-cache')), 'purge-entire-cache') ?>">Purge Entire Cache</a>
+            <h3><?php esc_html_e('Purge Cache', 'clp-varnish-cache'); ?></h3>
+            <a class="button button-primary" href="<?php echo wp_nonce_url($form_action_url . '&action=purge-entire-cache', 'purge-entire-cache'); ?>">Purge Entire Cache</a>
           </div>
           <div class="clp-varnish-cache-block-content clp-varnish-cache-block-purge-cache">
             <table class="form-table">
@@ -182,39 +149,31 @@ $excludes = $clp_cache_manager->get_excludes();
                 <tr>
                   <td>
                     <input type="text" name="purge-value" required="required" class="purge-value" placeholder="https://www.domain.com/site.html">
-                    <p class="description"><?php esc_html_e( 'You can purge single urls or tags separated by comma.', 'clp-varnish-cache' ); ?></p>
+                    <p class="description"><?php esc_html_e('You can purge single urls or tags separated by comma.', 'clp-varnish-cache'); ?></p>
                   </td>
                 </tr>
               </tbody>
             </table>
-            <?php wp_nonce_field( 'clp_varnish_purge_cache', 'clp_varnish_nonce' ); ?>
+            <?php wp_nonce_field('clp_varnish_purge_cache', 'clp_varnish_nonce'); ?>
             <input type="hidden" name="action" value="purge-cache" />
-            <input type="submit" class="button action" value="<?php esc_html_e( 'Purge Cache', 'clp-varnish-cache' ); ?>" />
+            <input type="submit" class="button action" value="<?php esc_html_e('Purge Cache', 'clp-varnish-cache'); ?>" />
           </div>
         </div>
       </form>
       <div class="clp-varnish-cache-block">
         <div class="clp-varnish-cache-block-header">
-          <h3><?php esc_html_e( 'Support', 'clp-varnish-cache' ); ?></h3>
+          <h3><?php esc_html_e('Support', 'clp-varnish-cache'); ?></h3>
         </div>
          <div class="clp-varnish-cache-block-content">
            <table class="form-table">
              <tbody>
                <tr>
-                 <td class="field-name">
-                   <?php esc_html_e( 'Documentation', 'clp-varnish-cache' ); ?>:
-                 </td>
-                 <td>
-                   <a target="_blank" href="https://www.cloudpanel.io/docs/v2/frontend-area/varnish-cache/wordpress/plugin/">https://www.cloudpanel.io/docs/v2/frontend-area/varnish-cache/wordpress/plugin/</a>
-                 </td>
+                 <td class="field-name"><?php esc_html_e('Documentation', 'clp-varnish-cache'); ?>:</td>
+                 <td><a target="_blank" href="https://www.cloudpanel.io/docs/v2/frontend-area/varnish-cache/wordpress/plugin/">https://www.cloudpanel.io/docs/v2/frontend-area/varnish-cache/wordpress/plugin/</a></td>
                </tr>
                <tr>
-                 <td class="field-name">
-                   <?php esc_html_e( 'Discord', 'clp-varnish-cache' ); ?>:
-                 </td>
-                 <td>
-                   <a target="_blank" href="https://discord.cloudpanel.io/">https://discord.cloudpanel.io/</a>
-                 </td>
+                 <td class="field-name"><?php esc_html_e('Discord', 'clp-varnish-cache'); ?>:</td>
+                 <td><a target="_blank" href="https://discord.cloudpanel.io/">https://discord.cloudpanel.io/</a></td>
                </tr>
              </tbody>
            </table>

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: varnish, varnish cache, cache, caching
 Requires at least: 6.0
 Tested up to: 6.9.1
 Requires PHP: 7.1
-Stable tag: 1.1.0
+Stable tag: 1.1.2
 License: GPLv3
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 SVN Repository: http://plugins.svn.wordpress.org/clp-varnish-cache/

--- a/style.css
+++ b/style.css
@@ -1,3 +1,5 @@
+/* === CLP Varnish Cache — CloudPanel-style UI === */
+
 #wp-admin-bar-clp-varnish-cache .ab-icon {
   float: left;
   width: 22px;
@@ -7,61 +9,271 @@
   background-size: 20px;
 }
 
+/* Container */
 .clp-varnish-cache-container {
-  max-width: 900px;
+  max-width: 1200px;
+  margin: 20px 0 0;
+  padding-right: 20px;
 }
 
-.clp-varnish-cache-container .notice {
-  margin: 0 !important;
-}
-
+/* Card */
 .clp-varnish-cache-block {
-  background-color: #fdfdfd;
-  border: 1px solid #e5e5e5;
-  box-shadow: 0 1px 1px #0000000a;
-  margin: 20px 0px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  margin: 0 0 20px;
+  overflow: hidden;
 }
 
+/* Card header */
 .clp-varnish-cache-block-header {
-  border-bottom: 1px solid #ccc;
-  padding: 10px;
   display: flex;
+  align-items: center;
   justify-content: space-between;
+  padding: 20px 24px;
+  border-bottom: 1px solid #e2e8f0;
+  background: #fff;
 }
 
 .clp-varnish-cache-block-header h3 {
-  margin: 5px 0px;
+  margin: 0;
   padding: 0;
-  font-size: 1.4em;
+  font-size: 15px;
+  font-weight: 600;
+  color: #1a202c;
+  display: flex;
+  align-items: center;
+  gap: 10px;
 }
 
+/* Card body */
 .clp-varnish-cache-block-content {
-  padding: 25px 20px;
+  padding: 24px;
   font-size: 14px;
 }
 
-.clp-varnish-cache-block-content .form-table {
-  margin-top: 0;
+/* Button row — no border, no background, part of the card body */
+.clp-varnish-cache-block-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0 24px 24px;
 }
 
-.clp-varnish-cache-block-content .form-table td {
-  padding: 10px 0px;
+/* 2-column form grid */
+.clp-form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 20px;
 }
 
-.clp-varnish-cache-block-content input[type=text],
-.clp-varnish-cache-block-content textarea {
+.clp-form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.clp-form-group.clp-full-col {
+  grid-column: 1 / -1;
+}
+
+.clp-form-group label {
+  font-size: 13px;
+  font-weight: 500;
+  color: #4a5568;
+}
+
+.clp-form-group label .clp-required {
+  color: #e53e3e;
+  margin-left: 2px;
+}
+
+/* Inputs & textarea */
+.clp-varnish-cache-container input[type="text"],
+.clp-varnish-cache-container textarea {
   width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #cbd5e0;
+  border-radius: 6px;
+  font-size: 14px;
+  font-family: inherit;
+  color: #2d3748;
+  background: #fff;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  box-sizing: border-box;
 }
 
-.clp-varnish-cache-block-content table {
-  margin-bottom: 10px;
+.clp-varnish-cache-container input[type="text"]:focus,
+.clp-varnish-cache-container textarea:focus {
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.12);
 }
 
-.clp-varnish-cache-block-content table td {
+.clp-varnish-cache-container textarea {
+  resize: vertical;
+  min-height: 120px;
+}
+
+/* Description text */
+.clp-varnish-cache-container p.description {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: #718096;
+}
+
+/* Toggle switch — sized to match text line height */
+.clp-toggle {
+  position: relative;
+  display: inline-block;
+  width: 28px;
+  height: 18px;
+  flex-shrink: 0;
+  vertical-align: middle;
+  margin-top: -1px;
+}
+
+.clp-toggle input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+  position: absolute;
+}
+
+.clp-toggle-slider {
+  position: absolute;
+  cursor: pointer;
+  inset: 0;
+  background: #cbd5e0;
+  border-radius: 24px;
+  transition: background 0.2s;
+}
+
+.clp-toggle-slider::before {
+  content: '';
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  left: 3px;
+  top: 3px;
+  background: #fff;
+  border-radius: 50%;
+  transition: transform 0.2s;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+}
+
+.clp-toggle input:checked + .clp-toggle-slider {
+  background: #3b82f6;
+}
+
+.clp-toggle input:checked + .clp-toggle-slider::before {
+  transform: translateX(10px);
+}
+
+/* Buttons — override WP defaults */
+.clp-varnish-cache-container .button.clp-btn-primary,
+.clp-varnish-cache-container input[type="submit"].button {
+  display: inline-flex;
+  align-items: center;
+  padding: 10px 28px;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid #3b82f6;
+  background: #3b82f6;
+  color: #fff;
+  text-shadow: none;
+  box-shadow: none;
+  height: auto;
+  line-height: 1.5;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.clp-varnish-cache-container .button.clp-btn-primary:hover,
+.clp-varnish-cache-container input[type="submit"].button:hover {
+  background: #2563eb;
+  border-color: #2563eb;
+  color: #fff;
+}
+
+/* "Purge Entire Cache" secondary button */
+.clp-varnish-cache-container .button.clp-btn-secondary {
+  display: inline-flex;
+  align-items: center;
+  padding: 10px 20px;
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid #cbd5e0;
+  background: #fff;
+  color: #4a5568;
+  text-shadow: none;
+  box-shadow: none;
+  height: auto;
+  line-height: 1.5;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.clp-varnish-cache-container .button.clp-btn-secondary:hover {
+  background: #f7fafc;
+  border-color: #a0aec0;
+  color: #2d3748;
+}
+
+/* Support table */
+.clp-support-table {
+  border-collapse: collapse;
+  width: auto;
+}
+
+.clp-support-table td {
+  padding: 7px 0;
+  font-size: 13px;
+  color: #4a5568;
   vertical-align: top;
 }
 
-.clp-varnish-cache-block-content table td.field-name {
-  width: 30%;
-  font-weight: bold;
+.clp-support-table td:first-child {
+  font-weight: 600;
+  width: 130px;
+  padding-right: 12px;
+}
+
+.clp-support-table a {
+  color: #3b82f6;
+  text-decoration: none;
+}
+
+.clp-support-table a:hover {
+  text-decoration: underline;
+}
+
+/* Notices */
+.clp-varnish-cache-container .notice {
+  margin: 0 0 16px !important;
+  border-radius: 6px;
+  border-left: none;
+  padding: 10px 16px;
+}
+
+/* Responsive */
+@media (max-width: 640px) {
+  .clp-varnish-cache-container {
+    padding-right: 12px;
+  }
+
+  .clp-form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .clp-form-group.clp-full-col {
+    grid-column: 1;
+  }
+
+  .clp-varnish-cache-block-header {
+    flex-wrap: wrap;
+    gap: 10px;
+  }
 }


### PR DESCRIPTION
Cleaning up some tech debt and fixing a couple of security gaps I noticed while looking through the code.

Here is a breakdown of what changed and why:
* **improved ui:** created a cloudpanel-style UI
* **centralized the cache purging (DRY):** created a single `purge_entire_cache()` method in the manager class. we were literally copy-pasting the exact same 5 lines of code to find the host and tag prefix across three different files (admin bar, auto-purge, and settings page). now it's all in one place, so if we ever need to change how purging works later, we only have to update it once.
* **added nonces (CSRF protection):** added `wp_nonce_field` and `wp_verify_nonce` checks to the settings page forms and the "purge entire cache" button. before this, the plugin just trusted any POST/GET request that had the right action name. this means an attacker could have theoretically tricked an admin into changing the varnish server or wiping the cache via a CSRF attack. this locks that down.
* **fixed json error suppression:** got rid of the `@json_decode` in the settings fetcher. using `@` to silently suppress errors is a bad habit because if the `settings.json` file gets corrupted, it just fails silently and makes debugging a total nightmare. swapped it out for a proper `json_last_error` check so it handles bad files gracefully... And is a bit more performant hahah
* **fixed php 8+ dependency:** swapped out `str_starts_with` for a standard `strpos(...) === 0` check. the plugin specifies PHP 7.1 as the minimum, but that function was introduced in 8.0, which would cause fatal errors on older server setups.
* **cleaned up formatting & yoda conditions:** stripped out all the bulky yoda conditions (`true === isset(...)` / `false === empty(...)`) and replaced them with cleaner null coalescing operators (`??`) and standard negation (`!empty()`). also aligned the code with our formatting standard (no spaces inside parentheses, brace-less one-line if statements).
* **removed dead code in svg icon:** there was a chunk of code in `get_svg_icon` that queried the database for wp admin colors, parsed json, and calculated a fill color, only to immediately overwrite it with a hardcoded hex value on the next line. stripped that out to save useless db queries and improve performance.

Additional effect of this PR is that it let's people more easily purge cache via plugins like the code snippets one since it provides a unified method.